### PR TITLE
gorilla/mux -> go-chi/chi/v5

### DIFF
--- a/server/game/service/websocket.go
+++ b/server/game/service/websocket.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gorilla/mux"
+	"github.com/go-chi/chi/v5"
 	"github.com/gorilla/websocket"
 	"golang.org/x/xerrors"
 
@@ -68,8 +68,8 @@ func (sv *GameService) serveWebSocket(ctx context.Context) <-chan error {
 		}
 
 		ws := &WSHandler{sv}
-		r := mux.NewRouter()
-		r.HandleFunc("/room/{id:[0-9a-f]+}", ws.HandleRoom).Methods("GET")
+		r := chi.NewMux()
+		r.Get("/room/{id:[0-9a-f]+}", ws.HandleRoom)
 
 		sv.wsURLFormat = fmt.Sprintf("%s://%s:%d/room/%%s",
 			scheme, sv.conf.PublicName, sv.conf.WebsocketPort)
@@ -87,8 +87,7 @@ func (sv *GameService) serveWebSocket(ctx context.Context) <-chan error {
 }
 
 func (s *WSHandler) HandleRoom(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	roomId := vars["id"]
+	roomId := chi.URLParam(r, "id")
 	appId := r.Header.Get("Wsnet2-App")
 	clientId := r.Header.Get("Wsnet2-User")
 	logger := log.GetLoggerWith(

--- a/server/go.mod
+++ b/server/go.mod
@@ -5,7 +5,6 @@ go 1.19
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/go-chi/chi/v5 v5.0.8
-	github.com/go-chi/hostrouter v0.2.0
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/google/go-cmp v0.5.7
 	github.com/gorilla/websocket v1.4.2

--- a/server/go.mod
+++ b/server/go.mod
@@ -4,9 +4,10 @@ go 1.19
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
+	github.com/go-chi/chi/v5 v5.0.8
+	github.com/go-chi/hostrouter v0.2.0
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/google/go-cmp v0.5.7
-	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2
 	github.com/jmoiron/sqlx v1.3.4
 	github.com/pelletier/go-toml v1.9.4

--- a/server/go.sum
+++ b/server/go.sum
@@ -112,6 +112,11 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-chi/chi/v5 v5.0.0/go.mod h1:BBug9lr0cqtdAhsu6R4AAdvufI0/XBzAQSsUqJpoZOs=
+github.com/go-chi/chi/v5 v5.0.8 h1:lD+NLqFcAi1ovnVZpsnObHGW4xb4J8lNmoYVfECH1Y0=
+github.com/go-chi/chi/v5 v5.0.8/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/go-chi/hostrouter v0.2.0 h1:GwC7TZz8+SlJN/tV/aeJgx4F+mI5+sp+5H1PelQUjHM=
+github.com/go-chi/hostrouter v0.2.0/go.mod h1:pJ49vWVmtsKRKZivQx0YMYv4h0aX+Gcn6V23Np9Wf1s=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -200,8 +205,6 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
 github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0eJc8R6ouapiM=
-github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
-github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
@@ -558,10 +561,7 @@ golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220207234003-57398862261d h1:Bm7BNOQt2Qv7ZqysjeLjgCBanX+88Z/OtdvsrEv1Djc=
-golang.org/x/sys v0.0.0-20220207234003-57398862261d h1:Bm7BNOQt2Qv7ZqysjeLjgCBanX+88Z/OtdvsrEv1Djc=
 golang.org/x/sys v0.0.0-20220207234003-57398862261d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220207234003-57398862261d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/server/go.sum
+++ b/server/go.sum
@@ -112,11 +112,8 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/go-chi/chi/v5 v5.0.0/go.mod h1:BBug9lr0cqtdAhsu6R4AAdvufI0/XBzAQSsUqJpoZOs=
 github.com/go-chi/chi/v5 v5.0.8 h1:lD+NLqFcAi1ovnVZpsnObHGW4xb4J8lNmoYVfECH1Y0=
 github.com/go-chi/chi/v5 v5.0.8/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
-github.com/go-chi/hostrouter v0.2.0 h1:GwC7TZz8+SlJN/tV/aeJgx4F+mI5+sp+5H1PelQUjHM=
-github.com/go-chi/hostrouter v0.2.0/go.mod h1:pJ49vWVmtsKRKZivQx0YMYv4h0aX+Gcn6V23Np9Wf1s=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/server/hub/service/websocket.go
+++ b/server/hub/service/websocket.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gorilla/mux"
+	"github.com/go-chi/chi/v5"
 	"github.com/gorilla/websocket"
 	"golang.org/x/xerrors"
 
@@ -68,8 +68,8 @@ func (sv *HubService) serveWebSocket(ctx context.Context) <-chan error {
 		}
 
 		ws := &WSHandler{sv}
-		r := mux.NewRouter()
-		r.HandleFunc("/room/{id:[0-9a-f]+}", ws.HandleRoom).Methods("GET")
+		r := chi.NewMux()
+		r.Get("/room/{id:[0-9a-f]+}", ws.HandleRoom)
 
 		sv.wsURLFormat = fmt.Sprintf("%s://%s:%d/room/%%s",
 			scheme, sv.conf.PublicName, sv.conf.WebsocketPort)
@@ -87,8 +87,7 @@ func (sv *HubService) serveWebSocket(ctx context.Context) <-chan error {
 }
 
 func (s *WSHandler) HandleRoom(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	roomId := vars["id"]
+	roomId := chi.URLParam(r, "id")
 	clientId := r.Header.Get("Wsnet2-User")
 	lastEvSeq, err := strconv.Atoi(r.Header.Get("Wsnet2-LastEventSeq"))
 	if err != nil {

--- a/server/lobby/service/api.go
+++ b/server/lobby/service/api.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/go-chi/hostrouter"
 	"github.com/vmihailenco/msgpack/v5"
 	"golang.org/x/xerrors"
 
@@ -80,22 +79,15 @@ func (sv *LobbyService) registerRoutes(r chi.Router) {
 	r.Get("/health", handleHealth)
 	r.Get("/health/", handleHealth)
 
-	// subroutes
-	r2 := chi.NewRouter()
-	r2.Post("/rooms", sv.handleCreateRoom)
-	r2.Post("/rooms/join/id/{roomId}", sv.handleJoinRoom)
-	r2.Post("/rooms/join/number/{roomNumber:[0-9]+}", sv.handleJoinRoomByNumber)
-	r2.Post("/rooms/join/random/{searchGroup:[0-9]+}", sv.handleJoinRoomAtRandom)
-	r2.Post("/rooms/search", sv.handleSearchRooms)
-	r2.Post("/rooms/search/ids", sv.handleSearchByIds)
-	r2.Post("/rooms/watch/id/{roomId}", sv.handleWatchRoom)
-	r2.Post("/rooms/watch/number/{roomNumber:[0-9]+}", sv.handleWatchRoomByNumber)
-	r2.Post("/_admin/kick", sv.handleAdminKick)
-
-	hr := hostrouter.New()
-	hr.Map(sv.conf.Hostname, r2)
-
-	r.Mount("/", hr)
+	r.Post("/rooms", sv.handleCreateRoom)
+	r.Post("/rooms/join/id/{roomId}", sv.handleJoinRoom)
+	r.Post("/rooms/join/number/{roomNumber:[0-9]+}", sv.handleJoinRoomByNumber)
+	r.Post("/rooms/join/random/{searchGroup:[0-9]+}", sv.handleJoinRoomAtRandom)
+	r.Post("/rooms/search", sv.handleSearchRooms)
+	r.Post("/rooms/search/ids", sv.handleSearchByIds)
+	r.Post("/rooms/watch/id/{roomId}", sv.handleWatchRoom)
+	r.Post("/rooms/watch/number/{roomNumber:[0-9]+}", sv.handleWatchRoomByNumber)
+	r.Post("/_admin/kick", sv.handleAdminKick)
 }
 
 type header struct {

--- a/server/lobby/service/api.go
+++ b/server/lobby/service/api.go
@@ -13,7 +13,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gorilla/mux"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/hostrouter"
 	"github.com/vmihailenco/msgpack/v5"
 	"golang.org/x/xerrors"
 
@@ -61,7 +62,7 @@ func (sv *LobbyService) serveAPI(ctx context.Context) <-chan error {
 			}
 		}
 
-		r := mux.NewRouter()
+		r := chi.NewMux()
 		sv.registerRoutes(r)
 
 		errCh <- http.Serve(listener, r)
@@ -75,23 +76,26 @@ func handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("wsnet2 works\n"))
 }
 
-func (sv *LobbyService) registerRoutes(r *mux.Router) {
-	r.HandleFunc("/health", handleHealth).Methods("GET")
-	r.HandleFunc("/health/", handleHealth).Methods("GET")
+func (sv *LobbyService) registerRoutes(r chi.Router) {
+	r.Get("/health", handleHealth)
+	r.Get("/health/", handleHealth)
 
-	if sv.conf.Hostname != "" {
-		r = r.Host(sv.conf.Hostname).Subrouter()
-	}
+	// subroutes
+	r2 := chi.NewRouter()
+	r2.Post("/rooms", sv.handleCreateRoom)
+	r2.Post("/rooms/join/id/{roomId}", sv.handleJoinRoom)
+	r2.Post("/rooms/join/number/{roomNumber:[0-9]+}", sv.handleJoinRoomByNumber)
+	r2.Post("/rooms/join/random/{searchGroup:[0-9]+}", sv.handleJoinRoomAtRandom)
+	r2.Post("/rooms/search", sv.handleSearchRooms)
+	r2.Post("/rooms/search/ids", sv.handleSearchByIds)
+	r2.Post("/rooms/watch/id/{roomId}", sv.handleWatchRoom)
+	r2.Post("/rooms/watch/number/{roomNumber:[0-9]+}", sv.handleWatchRoomByNumber)
+	r2.Post("/_admin/kick", sv.handleAdminKick)
 
-	r.HandleFunc("/rooms", sv.handleCreateRoom).Methods("POST")
-	r.HandleFunc("/rooms/join/id/{roomId}", sv.handleJoinRoom).Methods("POST")
-	r.HandleFunc("/rooms/join/number/{roomNumber:[0-9]+}", sv.handleJoinRoomByNumber).Methods("POST")
-	r.HandleFunc("/rooms/join/random/{searchGroup:[0-9]+}", sv.handleJoinRoomAtRandom).Methods("POST")
-	r.HandleFunc("/rooms/search", sv.handleSearchRooms).Methods("POST")
-	r.HandleFunc("/rooms/search/ids", sv.handleSearchByIds).Methods("POST")
-	r.HandleFunc("/rooms/watch/id/{roomId}", sv.handleWatchRoom).Methods("POST")
-	r.HandleFunc("/rooms/watch/number/{roomNumber:[0-9]+}", sv.handleWatchRoomByNumber).Methods("POST")
-	r.HandleFunc("/_admin/kick", sv.handleAdminKick).Methods("POST")
+	hr := hostrouter.New()
+	hr.Map(sv.conf.Hostname, r2)
+
+	r.Mount("/", hr)
 }
 
 type header struct {
@@ -247,15 +251,24 @@ func (sv *LobbyService) handleCreateRoom(w http.ResponseWriter, r *http.Request)
 	renderJoinedRoomResponse(w, room, logger)
 }
 
-type JoinVars map[string]string
+type JoinVars struct {
+	ctx *chi.Context
+}
+
+func NewJoinVars(r *http.Request) *JoinVars {
+	return &JoinVars{
+		ctx: chi.RouteContext(r.Context()),
+	}
+}
 
 func (vars JoinVars) roomId() string {
-	id := vars["roomId"]
+	id := vars.ctx.URLParam("roomId")
 	return id
 }
 
 func (vars JoinVars) roomNumber() (number int32) {
-	if v, found := vars["roomNumber"]; found {
+	v := vars.ctx.URLParam("roomNumber")
+	if v != "" {
 		n, _ := strconv.ParseInt(v, 10, 32)
 		number = int32(n)
 	}
@@ -263,8 +276,9 @@ func (vars JoinVars) roomNumber() (number int32) {
 }
 
 func (vars JoinVars) searchGroup() (sg uint32) {
-	if v, found := vars["searchGroup"]; found {
-		n, _ := strconv.ParseUint(v, 10, 32)
+	v := vars.ctx.URLParam("searchGroup")
+	if v != "" {
+		n, _ := strconv.ParseInt(v, 10, 32)
 		sg = uint32(n)
 	}
 	return sg
@@ -297,7 +311,7 @@ func (sv *LobbyService) handleJoinRoom(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	vars := JoinVars(mux.Vars(r))
+	vars := NewJoinVars(r)
 	roomId := vars.roomId()
 	if roomId == "" {
 		renderErrorResponse(
@@ -342,7 +356,7 @@ func (sv *LobbyService) handleJoinRoomByNumber(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	vars := JoinVars(mux.Vars(r))
+	vars := NewJoinVars(r)
 	roomNumber := vars.roomNumber()
 	if roomNumber == 0 {
 		renderErrorResponse(
@@ -387,7 +401,7 @@ func (sv *LobbyService) handleJoinRoomAtRandom(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	vars := JoinVars(mux.Vars(r))
+	vars := NewJoinVars(r)
 	searchGroup := vars.searchGroup()
 	logger = logger.With(log.KeySearchGroup, searchGroup)
 
@@ -486,7 +500,7 @@ func (sv *LobbyService) handleWatchRoom(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	vars := JoinVars(mux.Vars(r))
+	vars := NewJoinVars(r)
 	roomId := vars.roomId()
 	if roomId == "" {
 		renderErrorResponse(
@@ -531,7 +545,7 @@ func (sv *LobbyService) handleWatchRoomByNumber(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	vars := JoinVars(mux.Vars(r))
+	vars := NewJoinVars(r)
 	roomNumber := vars.roomNumber()
 	if roomNumber == 0 {
 		renderErrorResponse(


### PR DESCRIPTION
gorillaプロジェクトがアーカイブしたので、 gorilla/mux から別のルーティングライブラリへの移行を検討しています。

catatsuy さんがおすすめしていたので、 go-chi への乗り換えを試してみました。
https://zenn.dev/catatsuy/articles/69222f6ce39b3a

route文字列のパターンは同じ `{変数名:正規表現}` が使えるので楽。
hostrouter あたりがちょっとだけ面倒。