### PR TITLE
use github.com/shiguredo/websocket

### DIFF
--- a/server/cmd/wsnet2-bot/bot.go
+++ b/server/cmd/wsnet2-bot/bot.go
@@ -14,7 +14,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gorilla/websocket"
+	"github.com/shiguredo/websocket"
 	"github.com/vmihailenco/msgpack/v5"
 
 	"wsnet2/auth"

--- a/server/game/peer.go
+++ b/server/game/peer.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"sync"
 
-	"github.com/gorilla/websocket"
+	"github.com/shiguredo/websocket"
 	"golang.org/x/xerrors"
 
 	"wsnet2/binary"

--- a/server/game/service/websocket.go
+++ b/server/game/service/websocket.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/gorilla/websocket"
+	"github.com/shiguredo/websocket"
 	"golang.org/x/xerrors"
 
 	"wsnet2/game"

--- a/server/go.mod
+++ b/server/go.mod
@@ -7,9 +7,9 @@ require (
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/google/go-cmp v0.5.7
-	github.com/gorilla/websocket v1.4.2
 	github.com/jmoiron/sqlx v1.3.4
 	github.com/pelletier/go-toml v1.9.4
+	github.com/shiguredo/websocket v1.6.0
 	github.com/spf13/cobra v1.3.0
 	github.com/vmihailenco/msgpack/v5 v5.3.5
 	go.uber.org/zap v1.21.0

--- a/server/go.sum
+++ b/server/go.sum
@@ -202,8 +202,6 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
 github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0eJc8R6ouapiM=
-github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
-github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.11.0/go.mod h1:XjsvQN+RJGWI2TWy1/kqaE16HrR2J/FWgkYjdZQsX9M=
 github.com/hashicorp/consul/sdk v0.8.0/go.mod h1:GBvyrGALthsZObzUGsfgHZQDXjg4lOjagTIwIR1vPms=
@@ -321,6 +319,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sagikazarmark/crypt v0.3.0/go.mod h1:uD/D+6UF4SrIR1uGEv7bBNkNqLGqUr43MRiaGWX1Nig=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/shiguredo/websocket v1.6.0 h1:TDogwJfOEyMY/gV6vwckgy3VA7e9FP3YoK3j6i2zh+g=
+github.com/shiguredo/websocket v1.6.0/go.mod h1:1j84dsw/2bDlUCmtjASjZbEBNWn5GvVZLIUs9aS6Ntk=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/server/hub/hub.go
+++ b/server/hub/hub.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gorilla/websocket"
+	"github.com/shiguredo/websocket"
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc/codes"

--- a/server/hub/repository.go
+++ b/server/hub/repository.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gorilla/websocket"
 	"github.com/jmoiron/sqlx"
+	"github.com/shiguredo/websocket"
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"

--- a/server/hub/service/websocket.go
+++ b/server/hub/service/websocket.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/gorilla/websocket"
+	"github.com/shiguredo/websocket"
 	"golang.org/x/xerrors"
 
 	"wsnet2/game"


### PR DESCRIPTION
`github.com/gorilla/websocket` が更新停止してしまったので、[時雨堂さんのfork](https://github.com/shiguredo/websocket)に置き換えました。
importしている場所多くないので直接書き換えました。