### PR TITLE
EvPong refactoring

### DIFF
--- a/wsnet2-dotnet/WSNet2.Core.Test/EvPongTest.cs
+++ b/wsnet2-dotnet/WSNet2.Core.Test/EvPongTest.cs
@@ -1,7 +1,5 @@
 using NUnit.Framework;
-using System;
 using System.Collections.Generic;
-using System.Security.Cryptography;
 
 namespace WSNet2.Core.Test
 {

--- a/wsnet2-dotnet/WSNet2.Core.Test/EvPongTest.cs
+++ b/wsnet2-dotnet/WSNet2.Core.Test/EvPongTest.cs
@@ -1,0 +1,32 @@
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+
+namespace WSNet2.Core.Test
+{
+    public class EvPongTest
+    {
+        [Test]
+        public void TestEvPongPayload()
+        {
+            var payload = new byte[]{
+                (byte)Type.ULong, 1,2,3,4,5,6,7,8,
+                (byte)Type.UInt, 0,0,0,9,
+                (byte)Type.Dict, 2,
+                1, (byte)'a', 0, 9, (byte)Type.ULong, 2,3,4,5,6,7,8,9,
+                2, (byte)'b', (byte)'b', 0, 9, (byte)Type.ULong, 3,4,5,6,7,8,9,10,
+            };
+            var explmts = new Dictionary<string, ulong>(){{"a", 0x0203040506070809}, {"bb", 0x030405060708090a}};
+
+            var reader = WSNet2Serializer.NewReader(payload);
+            var ev = new EvPong(reader);
+            var lmts = new Dictionary<string, ulong>(){{"a", 1}, {"bb", 2}};
+            ev.GetLastMsgTimestamps(lmts);
+
+            Assert.AreEqual(0x0102030405060708, ev.PingTimestamp);
+            Assert.AreEqual(9, ev.WatcherCount);
+            Assert.AreEqual(explmts, lmts);
+        }
+    }
+}

--- a/wsnet2-dotnet/WSNet2.Core.Test/EvResponseTest.cs
+++ b/wsnet2-dotnet/WSNet2.Core.Test/EvResponseTest.cs
@@ -54,5 +54,27 @@ namespace WSNet2.Core.Test
             Assert.AreEqual(publicProps, payload.PublicProps);
             Assert.AreEqual(privateProps, payload.PrivateProps);
         }
+
+        [Test]
+        public void TestEvPongPayload()
+        {
+            var payload = new byte[]{
+                (byte)Type.ULong, 1,2,3,4,5,6,7,8,
+                (byte)Type.UInt, 0,0,0,9,
+                (byte)Type.Dict, 2,
+                1, (byte)'a', 0, 9, (byte)Type.ULong, 2,3,4,5,6,7,8,9,
+                2, (byte)'b', (byte)'b', 0, 9, (byte)Type.ULong, 3,4,5,6,7,8,9,10,
+            };
+            var explmts = new Dictionary<string, ulong>(){{"a", 0x0203040506070809}, {"bb", 0x030405060708090a}};
+
+            var reader = WSNet2Serializer.NewReader(payload);
+            var ev = new EvPong(reader);
+            var lmts = new Dictionary<string, ulong>(){{"a", 1}, {"bb", 2}};
+            ev.GetLastMsgTimestamps(lmts);
+
+            Assert.AreEqual(0x0102030405060708, ev.PingTimestamp);
+            Assert.AreEqual(9, ev.WatcherCount);
+            Assert.AreEqual(explmts, lmts);
+        }
     }
 }

--- a/wsnet2-dotnet/WSNet2.Core.Test/EvResponseTest.cs
+++ b/wsnet2-dotnet/WSNet2.Core.Test/EvResponseTest.cs
@@ -5,7 +5,7 @@ using System.Security.Cryptography;
 
 namespace WSNet2.Core.Test
 {
-    public class EvResponsePayloadTests
+    public class EvResponseTests
     {
         MsgPool msgpool;
 
@@ -53,28 +53,6 @@ namespace WSNet2.Core.Test
             Assert.AreEqual(clientDeadline, payload.ClientDeadline);
             Assert.AreEqual(publicProps, payload.PublicProps);
             Assert.AreEqual(privateProps, payload.PrivateProps);
-        }
-
-        [Test]
-        public void TestEvPongPayload()
-        {
-            var payload = new byte[]{
-                (byte)Type.ULong, 1,2,3,4,5,6,7,8,
-                (byte)Type.UInt, 0,0,0,9,
-                (byte)Type.Dict, 2,
-                1, (byte)'a', 0, 9, (byte)Type.ULong, 2,3,4,5,6,7,8,9,
-                2, (byte)'b', (byte)'b', 0, 9, (byte)Type.ULong, 3,4,5,6,7,8,9,10,
-            };
-            var explmts = new Dictionary<string, ulong>(){{"a", 0x0203040506070809}, {"bb", 0x030405060708090a}};
-
-            var reader = WSNet2Serializer.NewReader(payload);
-            var ev = new EvPong(reader);
-            var lmts = new Dictionary<string, ulong>(){{"a", 1}, {"bb", 2}};
-            ev.GetLastMsgTimestamps(lmts);
-
-            Assert.AreEqual(0x0102030405060708, ev.PingTimestamp);
-            Assert.AreEqual(9, ev.WatcherCount);
-            Assert.AreEqual(explmts, lmts);
         }
     }
 }

--- a/wsnet2-dotnet/WSNet2.Core.Test/SerializeTests.cs
+++ b/wsnet2-dotnet/WSNet2.Core.Test/SerializeTests.cs
@@ -896,6 +896,73 @@ namespace WSNet2.Core.Test
         }
 
         [Test]
+        public void TestBoolDict()
+        {
+            Dictionary<string, bool> dic = null;
+            var expect = new byte[]{ (byte)Type.Null };
+            writer.Write(dic);
+            Assert.AreEqual(expect, writer.ArraySegment());
+            var reader = WSNet2Serializer.NewReader(writer.ArraySegment());
+            var r = reader.ReadBoolDict();
+            Assert.AreEqual(dic, r);
+
+            writer.Reset();
+            dic = new Dictionary<string, bool>(){};
+            expect = new byte[]{ (byte)Type.Dict, 0 };
+            writer.Write(dic);
+            Assert.AreEqual(expect, writer.ArraySegment());
+            reader = WSNet2Serializer.NewReader(writer.ArraySegment());
+            r = reader.ReadBoolDict();
+            Assert.AreEqual(dic, r);
+
+            writer.Reset();
+            dic = new Dictionary<string, bool>(){ {"a", true}, {"bb", false} };
+            expect = new byte[]{
+                (byte)Type.Dict, 2,
+                1, (byte)'a', 0, 1, (byte)Type.True, 2, (byte)'b', (byte)'b', 0, 1, (byte)Type.False,
+            };
+            writer.Write(dic);
+            Assert.AreEqual(expect, writer.ArraySegment());
+            reader = WSNet2Serializer.NewReader(writer.ArraySegment());
+            r = reader.ReadBoolDict();
+            Assert.AreEqual(dic, r);
+        }
+
+        [Test]
+        public void TestULongDict()
+        {
+            Dictionary<string, ulong> dic = null;
+            var expect = new byte[]{ (byte)Type.Null };
+            writer.Write(dic);
+            Assert.AreEqual(expect, writer.ArraySegment());
+            var reader = WSNet2Serializer.NewReader(writer.ArraySegment());
+            var r = reader.ReadULongDict();
+            Assert.AreEqual(dic, r);
+
+            writer.Reset();
+            dic = new Dictionary<string, ulong>(){};
+            expect = new byte[]{ (byte)Type.Dict, 0 };
+            writer.Write(dic);
+            Assert.AreEqual(expect, writer.ArraySegment());
+            reader = WSNet2Serializer.NewReader(writer.ArraySegment());
+            r = reader.ReadULongDict();
+            Assert.AreEqual(dic, r);
+
+            writer.Reset();
+            dic = new Dictionary<string, ulong>(){ {"a", 0x1020304050607080}, {"bb", 2} };
+            expect = new byte[]{
+                (byte)Type.Dict, 2,
+                1, (byte)'a', 0, 9, (byte)Type.ULong, 0x10,0x20,0x30,0x40,0x50,0x60,0x70,0x80,
+                2, (byte)'b', (byte)'b', 0, 9, (byte)Type.ULong, 0,0,0,0, 0,0,0,2,
+            };
+            writer.Write(dic);
+            Assert.AreEqual(expect, writer.ArraySegment());
+            reader = WSNet2Serializer.NewReader(writer.ArraySegment());
+            r = reader.ReadULongDict();
+            Assert.AreEqual(dic, r);
+        }
+
+        [Test]
         public void TestRead()
         {
             writer.Write();

--- a/wsnet2-dotnet/WSNet2.Core.Test/SerializeTests.cs
+++ b/wsnet2-dotnet/WSNet2.Core.Test/SerializeTests.cs
@@ -963,6 +963,23 @@ namespace WSNet2.Core.Test
         }
 
         [Test]
+        public void TestReadIntoULongDict()
+        {
+            var data = new byte[]{
+                (byte)Type.Dict, 2,
+                1, (byte)'a', 0, 9, (byte)Type.ULong, 0,0,0,0, 0,0,0,1,
+                2, (byte)'b', (byte)'b', 0, 9, (byte)Type.ULong, 0,0,0,0, 0,0,0,2,
+            };
+            var expect = new Dictionary<string, ulong>(){{"a", 1}, {"bb", 2}};
+            var olddict = new Dictionary<string, ulong>(){{"a", 10}, {"bb", 20}};
+            var reader = WSNet2Serializer.NewReader(data);
+
+            var newdict = reader.ReadIntoULongDict(olddict);
+            Assert.AreEqual(expect, newdict);
+            Assert.AreSame(newdict, olddict);
+        }
+
+        [Test]
         public void TestRead()
         {
             writer.Write();

--- a/wsnet2-unity/Assets/WSNet2/Scripts/Core/Event/EvPong.cs
+++ b/wsnet2-unity/Assets/WSNet2/Scripts/Core/Event/EvPong.cs
@@ -8,7 +8,8 @@ namespace WSNet2
         public ulong PingTimestamp { get; private set; }
         public ulong RTT { get; private set; }
         public uint WatcherCount { get; private set; }
-        public Dictionary<string, ulong> lastMsgTimestamps { get; private set; }
+
+        Dictionary<string, ulong> lastMsgTimestamps;
 
         public EvPong(SerialReader reader) : base(EvType.Pong, reader)
         {
@@ -16,9 +17,21 @@ namespace WSNet2
 
             PingTimestamp = reader.ReadULong();
             WatcherCount = reader.ReadUInt();
-            lastMsgTimestamps = reader.ReadULongDict();
-
             RTT = now - PingTimestamp;
+        }
+
+        public void GetLastMsgTimestamps(Dictionary<string, ulong> output)
+        {
+            if (lastMsgTimestamps == null)
+            {
+                lastMsgTimestamps = reader.ReadIntoULongDict(output);
+                return;
+            }
+
+            foreach (var kv in lastMsgTimestamps)
+            {
+                output[kv.Key] = kv.Value;
+            }
         }
     }
 }

--- a/wsnet2-unity/Assets/WSNet2/Scripts/Core/NetworkInformer.cs
+++ b/wsnet2-unity/Assets/WSNet2/Scripts/Core/NetworkInformer.cs
@@ -480,6 +480,8 @@ namespace WSNet2
                         };
                         break;
                     case EvPong evPong:
+                        var lastMsgTimestamps = new Dictionary<string, ulong>();
+                        evPong.GetLastMsgTimestamps(lastMsgTimestamps);
                         info = new RoomReceivePongInfo()
                         {
                             BodySize = bodySize,
@@ -489,7 +491,7 @@ namespace WSNet2
                             PingTimestampMilliSec = evPong.PingTimestamp,
                             RTT = evPong.RTT,
                             WatcherCount = evPong.WatcherCount,
-                            LastMsgTimestamps = evPong.lastMsgTimestamps,
+                            LastMsgTimestamps = lastMsgTimestamps,
                         };
                         break;
                     case EvJoined evJoined:

--- a/wsnet2-unity/Assets/WSNet2/Scripts/Core/SerialReader.cs
+++ b/wsnet2-unity/Assets/WSNet2/Scripts/Core/SerialReader.cs
@@ -803,7 +803,21 @@ namespace WSNet2
                 return null;
             }
 
-            var dict = new Dictionary<string, ulong>();
+            pos--;
+            return ReadIntoULongDict(new Dictionary<string, ulong>());
+        }
+
+        /// <summary>
+        ///   ulong辞書を読み取り既存のulong辞書に書き込む
+        /// </summary>
+        /// <remarks>
+        ///   既存dictの要素は削除せず追記する。
+        ///   Room.lastMsgTimestampsを直接書き換えるのに利用する。
+        /// </remarks>
+        public Dictionary<string, ulong> ReadIntoULongDict(Dictionary<string, ulong> dict)
+        {
+            checkType(Type.Dict);
+
             var count = Get8();
 
             for (var i = 0; i < count; i++)


### PR DESCRIPTION
EvPongでDictionaryを使い回すように修正しました。
WSNet2内部では使ってなかったBoolとULongの辞書のシリアライズが動いていなかったのであわせて修正しました。