### PR TITLE
独立goroutineでpeer.Close

### DIFF
--- a/server/game/client.go
+++ b/server/game/client.go
@@ -260,7 +260,7 @@ func (c *Client) Removed(cause string) {
 	p := c.peer
 	c.mu.RUnlock()
 	if p != nil {
-		p.Close(c.removeCause)
+		go p.Close(c.removeCause)
 	}
 }
 


### PR DESCRIPTION
WebSocketの書き込みが詰まることが、RoomのMsgLoopにまで伝播することがあったのを修正。

`client.Removed()`は`Room.MsgLoop()`のgoroutineで呼び出されていた。
このなかで呼ぶ`peer.Close()`がwebsocket書き込み用のロック(`peer.muWrite`)を取るので
外の場所での書き込みでロックを掴んだままだとRoomのMsgLoopまで止まってしまっていた。

`peer.Close()`は呼ばれたらそのPeerが終わるだけなので、非同期で呼んだとしても問題ない
（他の送信が先に終わったらもちろん問題ないし、先にCloseしても残りは再接続してきた新しいPeerで再送される）