### PR TITLE
wsnet2-toolの強化

### DIFF
--- a/server/cmd/wsnet2-tool/cmd/oldroom.go
+++ b/server/cmd/wsnet2-tool/cmd/oldroom.go
@@ -88,26 +88,34 @@ func selectRoomHistory(ctx context.Context, ids []string) (map[string]*roomHisto
 	return m, nil
 }
 
-func formatRoomHistory(r *roomHistory) (map[string]interface{}, error) {
+func formatRoomHistory(r *roomHistory) (_ map[string]any, err error) {
 	var number int32
 	if r.Number.Valid {
 		number = r.Number.Int32
 	}
-	publicProps, err := binary.UnmarshalRecursive(r.PublicProps)
-	if err != nil {
-		return nil, err
+	var publicProps any
+	if len(r.PublicProps) > 0 {
+		publicProps, err = binary.UnmarshalRecursive(r.PublicProps)
+		if err != nil {
+			return nil, err
+		}
 	}
-	privateProps, err := binary.UnmarshalRecursive(r.PrivateProps)
-	if err != nil {
-		return nil, err
+	var privateProps any
+	if len(r.PrivateProps) > 0 {
+		privateProps, err = binary.UnmarshalRecursive(r.PrivateProps)
+		if err != nil {
+			return nil, err
+		}
 	}
-	var playerLogs interface{}
-	err = json.Unmarshal(r.PlayerLogs, &playerLogs)
-	if err != nil {
-		return nil, err
+	var playerLogs any
+	if len(r.PlayerLogs) > 0 {
+		err = json.Unmarshal(r.PlayerLogs, &playerLogs)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	return map[string]interface{}{
+	return map[string]any{
 		"id":            r.RoomID,
 		"app_id":        r.AppID,
 		"host_id":       r.HostID,

--- a/server/cmd/wsnet2-tool/cmd/oldrooms.go
+++ b/server/cmd/wsnet2-tool/cmd/oldrooms.go
@@ -100,7 +100,7 @@ func parseTime(t string) (*time.Time, error) {
 
 func selectRoomHistoryForList(ctx context.Context, limit int, before, after, at *time.Time) ([]*roomHistory, error) {
 	q := "SELECT app_id, host_id, room_id, number, search_group, max_players, public_props, private_props, player_logs, created, closed FROM room_history"
-	p := []interface{}{}
+	p := []any{}
 	var where []string
 	if before != nil {
 		where = append(where, "created <= ?")
@@ -132,7 +132,7 @@ func playerIds(data []byte) ([]string, error) {
 		return []string{}, nil
 	}
 
-	var logs []map[string]interface{}
+	var logs []map[string]any
 	err := json.Unmarshal(data, &logs)
 	if err != nil {
 		return nil, err

--- a/server/game/room.go
+++ b/server/game/room.go
@@ -183,8 +183,8 @@ func (r *Room) removeLastMsg(cid ClientID) {
 	delete(r.lastMsg, string(cid))
 }
 
-/// UpdateLastMsg : PlayerがMsgを受信したとき更新する.
-/// 既に登録されているPlayerのみ書き込み (watcherを含めないため)
+// UpdateLastMsg : PlayerがMsgを受信したとき更新する.
+// 既に登録されているPlayerのみ書き込み (watcherを含めないため)
 func (r *Room) updateLastMsg(cid ClientID) {
 	id := string(cid)
 	if _, ok := r.lastMsg[id]; ok {
@@ -820,11 +820,20 @@ func (r *Room) msgGetRoomInfo(msg *MsgGetRoomInfo) error {
 	for _, id := range r.masterOrder {
 		cis = append(cis, r.players[id].ClientInfo.Clone())
 	}
+	lmt := make(map[string]uint64)
+	for p, d := range r.lastMsg {
+		t, _, err := binary.UnmarshalAs(d, binary.TypeULong)
+		if err != nil {
+			return xerrors.Errorf("Unmarshal LastMsg[%s]: %w", p, err)
+		}
+		lmt[p] = t.(uint64)
+	}
 
 	msg.Res <- &pb.GetRoomInfoRes{
-		RoomInfo:    ri,
-		ClientInfos: cis,
-		MasterId:    r.master.Id,
+		RoomInfo:     ri,
+		ClientInfos:  cis,
+		MasterId:     r.master.Id,
+		LastMsgTimes: lmt,
 	}
 
 	return nil

--- a/server/pb/gameservice.proto
+++ b/server/pb/gameservice.proto
@@ -59,6 +59,7 @@ message GetRoomInfoRes {
 	RoomInfo room_info = 1;
 	repeated ClientInfo client_infos = 2;
 	string master_id = 3;
+	map<string, uint64> last_msg_times = 4;
 }
 
 message KickReq {


### PR DESCRIPTION
- room
  - host_idだけでなくhost名も表示
  - 各playerのlast_msg_timeを表示
    - gRPCのGerRoomInfoのレスポンスに追加
  - interface{} -> any
- oldroom
  - public/private props、player_logsが空の時エラーになっていたのを修正
  - interface{} -> any
- oldrooms
  - interface{} -> any