### PR TITLE
Optimize with unsafe.String

### DIFF
--- a/server/binary/marshal.go
+++ b/server/binary/marshal.go
@@ -507,7 +507,7 @@ func unmarshalDict(src []byte) (Dict, int, error) {
 		if len(src) < l+lv {
 			return nil, 0, xerrors.Errorf("Unmarshal Dict[%q](%v..%v) error: not enough data (%v)", key, l, lv, len(src))
 		}
-		dict[string(key)] = src[l : l+lv]
+		dict[unsafeString(key)] = src[l : l+lv]
 		l += lv
 	}
 	return dict, l, nil

--- a/server/binary/marshal.go
+++ b/server/binary/marshal.go
@@ -350,7 +350,10 @@ func unmarshalStr8(src []byte) (string, int, error) {
 	if len(src) < 2+l {
 		return "", 0, xerrors.Errorf("Unmarshal Str8(%v) error: not enough data (%v)", l, len(src))
 	}
-	return string(src[2 : 2+l]), 2 + l, nil
+	if l == 0 {
+		return "", 2, nil
+	}
+	return unsafeString(src[2 : 2+l]), 2 + l, nil
 }
 
 // MarshalStr16 marshals long string (255 < len <= 65535)
@@ -375,7 +378,10 @@ func unmarshalStr16(src []byte) (string, int, error) {
 	if len(src) < 3+l {
 		return "", 0, xerrors.Errorf("Unmarshal Str16(%v) error: not enough data (%v)", l, len(src))
 	}
-	return string(src[3 : 3+l]), 3 + l, nil
+	if l == 0 {
+		return "", 3, nil
+	}
+	return unsafeString(src[3 : 3+l]), 3 + l, nil
 }
 
 // MarshalObj marshals Obj

--- a/server/binary/marshal.go
+++ b/server/binary/marshal.go
@@ -1074,6 +1074,8 @@ func MarshalStrings(vals []string) []byte {
 }
 
 // Unmarshal serialized bytes
+//
+// srcの領域はUnmarshal後に参照されるため書き換えてはいけない
 func Unmarshal(src []byte) (interface{}, int, error) {
 	if len(src) == 0 {
 		return nil, 0, xerrors.Errorf("Unmarshal error: empty")
@@ -1146,6 +1148,8 @@ func Unmarshal(src []byte) (interface{}, int, error) {
 }
 
 // Unmarshal bytes as specified type
+//
+// srcの領域はUnmarshal後に参照されるため書き換えてはいけない
 func UnmarshalAs(src []byte, types ...Type) (interface{}, int, error) {
 	if len(src) == 0 {
 		return nil, 0, xerrors.Errorf("Unmarshal error: empty")

--- a/server/binary/marshal_test.go
+++ b/server/binary/marshal_test.go
@@ -386,7 +386,7 @@ func TestMarshalStr8(t *testing.T) {
 			exp = exp[:255]
 		}
 		if r != string(exp) || l != len(test.buf) {
-			t.Fatalf("Unmarshal = %v (len=%v) wants %v (len=%v)", r, l, string(exp), len(test.buf))
+			t.Fatalf("Unmarshal(%q) = %v (len=%v) wants %v (len=%v)", test.val, r, l, string(exp), len(test.buf))
 		}
 	}
 }
@@ -409,7 +409,7 @@ func TestMarshalStr16(t *testing.T) {
 		{s256, append([]byte{byte(TypeStr16), 0x01, 0x00}, []byte(s256)...)},
 		{s65536, append([]byte{byte(TypeStr16), 0xff, 0xff}, []byte(s65536[:65535])...)},
 	}
-	for _, test := range tests {
+	for i, test := range tests {
 		b := MarshalStr16(test.val)
 		if !reflect.DeepEqual(b, test.buf) {
 			t.Fatalf("MarshalStr16:\n%#v\n%#v", b, test.buf)
@@ -423,7 +423,7 @@ func TestMarshalStr16(t *testing.T) {
 			exp = exp[:math.MaxUint16]
 		}
 		if r != string(exp) || l != len(test.buf) {
-			t.Fatalf("Unmarshal = %v (len=%v) wants %v (len=%v)", r, l, string(exp), len(test.buf))
+			t.Fatalf("Unmarshal[%v] = %v (len=%v) wants %v (len=%v)", i, r, l, string(exp), len(test.buf))
 		}
 	}
 }

--- a/server/binary/unmarshal_recursive.go
+++ b/server/binary/unmarshal_recursive.go
@@ -10,6 +10,8 @@ type RawObj struct {
 }
 
 // UnmarshalRecursive unmarshal all bytes recursive
+//
+// srcの領域はUnmarshal後に参照されるため書き換えてはいけない
 func UnmarshalRecursive(src []byte) (interface{}, error) {
 	if len(src) == 0 {
 		return nil, xerrors.Errorf("Unmarshal error: empty")

--- a/server/binary/unsafe_string118.go
+++ b/server/binary/unsafe_string118.go
@@ -1,0 +1,8 @@
+//go:build !go1.20
+
+package binary
+
+//go:inline
+func unsafeString(s []byte) string {
+	return string(s)
+}

--- a/server/binary/unsafe_string120.go
+++ b/server/binary/unsafe_string120.go
@@ -1,0 +1,10 @@
+//go:build go1.20
+
+package binary
+
+import "unsafe"
+
+//go:inline
+func unsafeString(s []byte) string {
+	return unsafe.String(&s[0], len(s))
+}


### PR DESCRIPTION
Go1.20で加わった[unsafe.String](https://pkg.go.dev/unsafe#String)を
`unmarshalDict`のキー文字列生成に使ったところ、[20%近く高速化](https://gist.github.com/makiuchi-d/f25be9bac360bdab40aef3f662a8d4a3)できました。

もともとデータ部分は受信したメモリ領域をそのままsliceとして切り出していたので書き換えることは無く、
キー文字列も`unsafe.String`を使えばメモリコピーを避けられて高速化します。

dashboardのbackendで使っているgopherjsがGo1.18を要求するので、
1.20以前ではこれまで通りstringへのキャストをするようにしています。