### PR TITLE
version情報をgit tagから取得、変数も統一

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -1,12 +1,13 @@
 # binaries to build
 TARGETS := bin/wsnet2-lobby bin/wsnet2-game bin/wsnet2-hub bin/wsnet2-bot bin/wsnet2-tool
+VERSION := $(shell git describe --tag 2>/dev/null || echo "v0.0.0")
 
 # dependencies
-PKG_LOBBY := cmd/wsnet2-lobby lobby lobby/service    auth binary common config log pb
-PKG_GAME  := cmd/wsnet2-game  game  game/service     auth binary common config log pb
-PKG_HUB   := cmd/wsnet2-hub   hub   hub/service game auth binary common config log pb
-PKG_BOT   := cmd/wsnet2-bot   lobby lobby/service    auth binary common config log pb
-PKG_TOOL  := cmd/wsnet2-tool cmd/wsnet2-tool/cmd          binary        config     pb
+PKG_LOBBY := cmd/wsnet2-lobby lobby lobby/service    auth binary common config log pb .
+PKG_GAME  := cmd/wsnet2-game  game  game/service     auth binary common config log pb .
+PKG_HUB   := cmd/wsnet2-hub   hub   hub/service game auth binary common config log pb .
+PKG_BOT   := cmd/wsnet2-bot   lobby lobby/service    auth binary common config log pb .
+PKG_TOOL  := cmd/wsnet2-tool cmd/wsnet2-tool/cmd          binary        config     pb .
 
 # protoc targets
 proto := $(wildcard pb/*.proto)
@@ -19,7 +20,7 @@ string.go := $(foreach s,$(stringer),\
                  $(dir $(word 1,$(subst >, ,$(s))))$(shell echo $(word 2,$(subst >, ,$(s))) | tr A-Z a-z))
 
 COMMIT := $(shell git rev-parse --short HEAD)
-GOBUILD := go build -ldflags "-X main.WSNet2Version=v0.0.1"
+GOBUILD := go build -ldflags "-X wsnet2.Version=$(VERSION)"
 
 export GOBIN := $(abspath bin)
 export PATH := $(GOBIN):$(PATH)

--- a/server/cmd/wsnet2-bot/main.go
+++ b/server/cmd/wsnet2-bot/main.go
@@ -8,15 +8,13 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	"wsnet2"
 )
 
 var (
 	appID  = "testapp"
 	appKey = "testapppkey"
-)
-
-var (
-	WSNet2Version string = "LOCAL"
 
 	logger *zap.SugaredLogger
 )
@@ -54,7 +52,7 @@ func main() {
 	logger = lg.Sugar()
 
 	fmt.Println("WSNet2-Bot")
-	fmt.Println("WSNet2Version:", WSNet2Version)
+	fmt.Println("WSNet2Version:", wsnet2.Version)
 	if bi, ok := debug.ReadBuildInfo(); ok {
 		for _, s := range bi.Settings {
 			if strings.HasPrefix(s.Key, "vcs.") {

--- a/server/cmd/wsnet2-game/main.go
+++ b/server/cmd/wsnet2-game/main.go
@@ -13,13 +13,10 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
 
+	"wsnet2"
 	"wsnet2/config"
 	"wsnet2/game/service"
 	"wsnet2/log"
-)
-
-var (
-	WSNet2Version string = "LOCAL"
 )
 
 func main() {
@@ -34,7 +31,7 @@ func main() {
 	defer log.InitLogger(&conf.Game.LogConf)()
 	log.SetLevel(log.Level(conf.Game.DefaultLoglevel))
 	log.Infof("WSNet2-Game")
-	log.Infof("WSNet2Version: %v", WSNet2Version)
+	log.Infof("WSNet2Version: %v", wsnet2.Version)
 	if bi, ok := debug.ReadBuildInfo(); ok {
 		for _, s := range bi.Settings {
 			if strings.HasPrefix(s.Key, "vcs.") {

--- a/server/cmd/wsnet2-hub/main.go
+++ b/server/cmd/wsnet2-hub/main.go
@@ -5,12 +5,15 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"runtime/debug"
+	"strings"
 	"syscall"
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
 
+	"wsnet2"
 	"wsnet2/config"
 	"wsnet2/hub/service"
 	"wsnet2/log"
@@ -27,6 +30,15 @@ func main() {
 
 	defer log.InitLogger(&conf.Hub.LogConf)()
 	log.SetLevel(log.Level(conf.Hub.DefaultLoglevel))
+	log.Infof("WSNet2-Hub")
+	log.Infof("WSNet2Version: %v", wsnet2.Version)
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		for _, s := range bi.Settings {
+			if strings.HasPrefix(s.Key, "vcs.") {
+				log.Infof("%v: %v", s.Key, s.Value)
+			}
+		}
+	}
 
 	db := sqlx.MustOpen("mysql", conf.Db.DSN())
 	maxConns := conf.Hub.DbMaxConns

--- a/server/cmd/wsnet2-lobby/main.go
+++ b/server/cmd/wsnet2-lobby/main.go
@@ -11,13 +11,10 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
 
+	"wsnet2"
 	"wsnet2/config"
 	"wsnet2/lobby/service"
 	"wsnet2/log"
-)
-
-var (
-	WSNet2Version string = "LOCAL"
 )
 
 func main() {
@@ -32,7 +29,7 @@ func main() {
 	defer log.InitLogger(&conf.Lobby.LogConf)()
 	log.SetLevel(log.Level(conf.Lobby.Loglevel))
 	log.Infof("WSNet2-Lobby")
-	log.Infof("WSNet2Version: %v", WSNet2Version)
+	log.Infof("WSNet2Version: %v", wsnet2.Version)
 	if bi, ok := debug.ReadBuildInfo(); ok {
 		for _, s := range bi.Settings {
 			if strings.HasPrefix(s.Key, "vcs.") {

--- a/server/cmd/wsnet2-tool/cmd/root.go
+++ b/server/cmd/wsnet2-tool/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/spf13/cobra"
 
+	"wsnet2"
 	"wsnet2/config"
 )
 
@@ -22,8 +23,7 @@ var (
 var rootCmd = &cobra.Command{
 	Use:   "wsnet2-tool",
 	Short: "WSNet2 tool",
-	Long:  `CLI tool for WSNet2`,
-
+	Long:  "CLI tool for WSNet2 " + wsnet2.Version,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if confFile == "" {
 			return fmt.Errorf("need --config option\n")

--- a/server/log/log.go
+++ b/server/log/log.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	"gopkg.in/natefinch/lumberjack.v2"
 
+	"wsnet2"
 	"wsnet2/config"
 )
 
@@ -179,7 +180,8 @@ func InitLogger(logconf *config.LogConf) func() {
 	}
 
 	host, _ := os.Hostname()
-	logger := zap.New(core, zap.WithCaller(true)).With(zap.String("host", host))
+	logger := zap.New(core, zap.WithCaller(true)).With(
+		zap.String("host", host), zap.String("version", wsnet2.Version))
 	rootLogger = logger
 	wrappedLogger = logger.WithOptions(zap.AddCallerSkip(1)).Sugar()
 

--- a/server/version.go
+++ b/server/version.go
@@ -1,0 +1,3 @@
+package wsnet2
+
+var Version = "LOCAL"


### PR DESCRIPTION
バイナリに埋め込むバージョン番号を `git describe --tag`  で取得するようにしました。
tagが一つもないときは `v0.0.0`になりますが、OSSリリース時点のコミットに `v0.0.1` を打っておきました。
構造化ログにもバージョンを含めるようにしました。
また設定する変数を今までは各バイナリのmain.goで定義していましたが、`wsnet2.Version` に統一しました。