### PR TITLE
player log table

### DIFF
--- a/server/cmd/wsnet2-tool/cmd/oldroom.go
+++ b/server/cmd/wsnet2-tool/cmd/oldroom.go
@@ -36,7 +36,7 @@ type playerLog struct {
 	RoomID   string            `db:"room_id" json:"-"`
 	PlayerID string            `db:"player_id" json:"player_id"`
 	Message  game.PlayerLogMsg `db:"message" json:"message"`
-	Datetime time.Time         `db:"datetime" json:"time"`
+	Datetime time.Time         `db:"datetime" json:"datetime"`
 }
 
 // oldroomCmd represents the oldroom command

--- a/server/cmd/wsnet2-tool/cmd/oldroom.go
+++ b/server/cmd/wsnet2-tool/cmd/oldroom.go
@@ -104,7 +104,7 @@ func selectRoomHistory(ctx context.Context, q string, p ...any) ([]*roomHistory,
 		rids = append(rids, r.RoomID)
 	}
 
-	q, p, err = sqlx.In("SELECT * FROM player_log WHERE room_id IN (?)", rids)
+	q, p, err = sqlx.In("SELECT * FROM player_log WHERE room_id IN (?) ORDER BY id", rids)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/game/client.go
+++ b/server/game/client.go
@@ -167,11 +167,13 @@ loop:
 			if c.peer == nil {
 				peerMsgCh = nil
 				curPeer = nil
+				c.room.Repo().PlayerLog(c, PlayerLogDetach)
 			} else {
 				c.connectCount++
 				c.logger.Infof("new peer attached: %v peer=%p", c.Id, c.peer)
 				peerMsgCh = c.peer.MsgCh()
 				curPeer = c.peer
+				c.room.Repo().PlayerLog(c, PlayerLogAttach)
 				// つなげて切るだけのクライアントをタイムアウトさせるため、t.Resetしない
 			}
 			c.mu.Unlock()

--- a/server/game/client.go
+++ b/server/game/client.go
@@ -167,13 +167,17 @@ loop:
 			if c.peer == nil {
 				peerMsgCh = nil
 				curPeer = nil
-				c.room.Repo().PlayerLog(c, PlayerLogDetach)
+				if c.isPlayer {
+					c.room.Repo().PlayerLog(c, PlayerLogDetach)
+				}
 			} else {
 				c.connectCount++
 				c.logger.Infof("new peer attached: %v peer=%p", c.Id, c.peer)
 				peerMsgCh = c.peer.MsgCh()
 				curPeer = c.peer
-				c.room.Repo().PlayerLog(c, PlayerLogAttach)
+				if c.isPlayer {
+					c.room.Repo().PlayerLog(c, PlayerLogAttach)
+				}
 				// つなげて切るだけのクライアントをタイムアウトさせるため、t.Resetしない
 			}
 			c.mu.Unlock()

--- a/server/game/interface.go
+++ b/server/game/interface.go
@@ -29,4 +29,5 @@ type IRoom interface {
 
 type IRepo interface {
 	RemoveClient(c *Client)
+	PlayerLog(c *Client, msg PlayerLogMsg)
 }

--- a/server/hub/repository.go
+++ b/server/hub/repository.go
@@ -206,3 +206,5 @@ func (r *Repository) GetHubCount() int {
 	defer r.mu.RUnlock()
 	return len(r.hubs)
 }
+
+func (r *Repository) PlayerLog(c *game.Client, msg game.PlayerLogMsg) {}

--- a/server/sql/10-schema.sql
+++ b/server/sql/10-schema.sql
@@ -60,11 +60,20 @@ CREATE TABLE `room_history` (
   `max_players` INTEGER UNSIGNED NOT NULL,
   `public_props` BLOB,
   `private_props` BLOB,
-  `player_logs` JSON,
   `created` DATETIME,
   `closed` DATETIME,
   KEY `room_id` (`room_id`),
   KEY `created` (`created`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+DROP TABLE IF EXISTS `player_log`;
+CREATE TABLE player_log (
+  `id`        BIGINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
+  `room_id`   VARCHAR(32) NOT NULL,
+  `player_id` VARCHAR(32) NOT NULL,
+  `message`   VARCHAR(32) NOT NULL,
+  `datetime`  DATETIME,
+  KEY `room_id` (`room_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS `hub`;

--- a/wsnet2-dashboard/backend/src/types/models/index.ts
+++ b/wsnet2-dashboard/backend/src/types/models/index.ts
@@ -5,3 +5,4 @@ export * from "./hub";
 export * from "./room_history";
 export * from "./room";
 export * from "./scalars";
+export * from "./player_log";

--- a/wsnet2-dashboard/backend/src/types/models/player_log.ts
+++ b/wsnet2-dashboard/backend/src/types/models/player_log.ts
@@ -1,0 +1,14 @@
+import { objectType } from "nexus";
+import { player_log } from "nexus-prisma";
+
+export const playerLogModel = objectType({
+  name: player_log.$name,
+  description: player_log.$description,
+  definition(t) {
+    t.field(player_log.id);
+    t.field(player_log.room_id);
+    t.field(player_log.player_id);
+    t.field(player_log.message);
+    t.field(player_log.datetime);
+  },
+});

--- a/wsnet2-dashboard/backend/src/types/models/room_history.ts
+++ b/wsnet2-dashboard/backend/src/types/models/room_history.ts
@@ -14,8 +14,16 @@ export const roomHistoryModel = objectType({
     t.field(room_history.max_players);
     t.field(room_history.public_props);
     t.field(room_history.private_props);
-    t.field(room_history.player_logs);
     t.field(room_history.created);
     t.field(room_history.closed);
+    t.list.field("player_logs", {
+      type: "player_log",
+      resolve(parent, _args, ctx) {
+        return ctx.prisma.player_log.findMany({
+          where: { room_id: parent.room_id },
+          orderBy: { id: "asc" },
+        });
+      },
+    });
   },
 });

--- a/wsnet2-dashboard/frontend/src/components/RoomHistoryDataTable.vue
+++ b/wsnet2-dashboard/frontend/src/components/RoomHistoryDataTable.vue
@@ -256,7 +256,7 @@ const columns = reactive<DataTableColumn[]>([
     key: "",
     render(data: unknown) {
       const row = data as RoomHistory;
-      return render(row.player_logs);
+      return render(row.player_logs.map((l) => `[${l.message}] ${l.player_id} : ${l.datetime}`));
     },
   },
 ]);

--- a/wsnet2-dashboard/frontend/src/store/roomHistories.ts
+++ b/wsnet2-dashboard/frontend/src/store/roomHistories.ts
@@ -20,9 +20,15 @@ export interface RoomHistory {
   max_players: number;
   public_props: Unmarshaled;
   private_props: Unmarshaled;
-  player_logs: object;
   created: string;
   closed: string;
+  player_logs: PlayerLog[];
+}
+
+export interface PlayerLog {
+  player_id: string;
+  message: string;
+  datetime: string;
 }
 
 export interface FetchRoomHistoriesInput {
@@ -90,9 +96,13 @@ class RoomHistoriesModule extends VuexModule {
             max_players
             public_props
             private_props
-            player_logs
             created
             closed
+            player_logs {
+              player_id
+              message
+              datetime
+            }
           }
         }
       `,


### PR DESCRIPTION
close: #28 

これまで`room_history`テーブルに保存していたPlayerの入室・再入室・退室のログ情報を別テーブル(`player_log`)に保存するようにしました。
加えて、peerのAttach・Detachもここに記録するようにしました。
なおhubでは記録しません。
