### PR TITLE
compose.yaml へのリネームと更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ docker compose up
 ```
 
 VM やリモート環境で起動する場合は、
-`docker-compose.yml`にて game/hub の接続ホスト名を環境変数`WSNET2_GAME_PUBLICNAME`で適切に指定してください。
+`compose.yaml`にて game/hub の接続ホスト名を環境変数`WSNET2_GAME_PUBLICNAME`で適切に指定してください。
 
 ### サンプルゲーム
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -8,6 +8,3 @@ RUN apt-get update && apt-get install -y unzip && \
 
 RUN go install github.com/makiuchi-d/arelo@latest && \
     git config --global --add safe.directory /repo
-
-RUN wget -O /wait-for-it.sh https://github.com/vishnubob/wait-for-it/raw/master/wait-for-it.sh > /dev/null 2>&1 && \
-    chmod +x /wait-for-it.sh

--- a/server/compose-multihost.yaml
+++ b/server/compose-multihost.yaml
@@ -1,4 +1,3 @@
-version: '3'
 name: wsnet2
 services:
   game2:

--- a/server/compose.yaml
+++ b/server/compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 name: wsnet2
 services:
   db:

--- a/server/compose.yaml
+++ b/server/compose.yaml
@@ -22,17 +22,19 @@ services:
           "CMD",
           "mysqladmin",
           "ping",
-          "-h",
-          "localhost",
-          "-u",
-          "root",
+          "-hlocalhost",
+          "--protocol=tcp",
+          "--port=3306",
+          "-uroot",
           "-p$$MYSQL_ROOT_PASSWORD",
         ]
-      timeout: 20s
+      interval: 3s
+      timeout: 1s
       retries: 10
+      start_period: 1m
   builder:
     container_name: wsnet2-builder
-    build: .
+    build: ../server
     image: wsnet2-arelo
     volumes:
       - ../:/repo
@@ -41,8 +43,9 @@ services:
   game:
     container_name: wsnet2-game
     depends_on:
-      - db
-    build: .
+      db:
+        condition: service_healthy
+    build: ../server
     image: wsnet2-arelo
     environment:
       WSNET2_GAME_HOSTNAME: wsnet2-game
@@ -54,7 +57,6 @@ services:
       - .log/:/var/log/wsnet2
     working_dir: /repo/server
     command: arelo -t "bin" -p "bin/wsnet2-game" -s SIGINT -- bin/wsnet2-game docker.toml
-    entrypoint: /wait-for-it.sh wsnet2-db:3306 -s -t 0 --
     ports:
       - 19000:19000
       - 8000:8000
@@ -62,9 +64,11 @@ services:
   hub:
     container_name: wsnet2-hub
     depends_on:
-      - db
-      - game
-    build: .
+      db:
+        condition: service_healthy
+      game:
+        condition: service_started
+    build: ../server
     image: wsnet2-arelo
     environment:
       WSNET2_GAME_HOSTNAME: wsnet2-hub
@@ -76,7 +80,6 @@ services:
       - .log/:/var/log/wsnet2
     working_dir: /repo/server
     command: arelo -t "bin" -p "bin/wsnet2-hub" -s SIGINT -- bin/wsnet2-hub docker.toml
-    entrypoint: /wait-for-it.sh wsnet2-db:3306 -s -t 0 --
     ports:
       - 19010:19010
       - 8010:8010
@@ -84,15 +87,15 @@ services:
   lobby:
     container_name: wsnet2-lobby
     depends_on:
-      - db
-    build: .
+      db:
+        condition: service_healthy
+    build: ../server
     image: wsnet2-arelo
     volumes:
       - ../:/repo
       - .log/:/var/log/wsnet2
     working_dir: /repo/server
     command: arelo -t "bin" -p "bin/wsnet2-lobby" -- bin/wsnet2-lobby docker.toml
-    entrypoint: /wait-for-it.sh wsnet2-db:3306 -s -t 0 --
     ports:
       - 8080:8080
       - 3080:3000

--- a/wsnet2-dashboard/README-ja.md
+++ b/wsnet2-dashboard/README-ja.md
@@ -28,7 +28,7 @@ wsnet2 のダッシュボード。
    ```
 2. `wsnet2-server` と `wsnet2-dashboard` を一緒に立ち上げる：
    ```bash
-   docker-compose -f docker-compose.yml -f ../server/docker-compose.yml up
+   docker compose -f compose.yaml -f ../server/compose.yaml up
    ```
    （`server`ディレクトリと`wsnet2-dashboard`ディレクトリのそれぞれで`docker compose up`することもできます）
 

--- a/wsnet2-dashboard/README.md
+++ b/wsnet2-dashboard/README.md
@@ -28,7 +28,7 @@ This webapp allows you to check real-time information on a running wsnet2 server
    ```
 2. Start `wsnet2-server` and `wsnet2-dashboard` together:
    ```bash
-   docker-compose -f docker-compose.yml -f ../server/docker-compose.yml up
+   docker compose -f compose.yaml -f ../server/compose.yaml up
    ```
 3. (Optional)Create a test room:
    ```bash

--- a/wsnet2-dashboard/backend/README-ja.md
+++ b/wsnet2-dashboard/backend/README-ja.md
@@ -18,7 +18,7 @@ wsnet2-dashboard 専用バックエンド（所謂 BFF）、
 データベースからスキーマを生成するので、`db`を起動しておく必要がある。
 
 ```bash
-docker compose -f server/docker-compose.yml up -d db
+docker compose -f server/compose.yaml up -d db
 cd wsnet2-dashboard
 docker compose run --rm backend make
 ```

--- a/wsnet2-dashboard/backend/README.md
+++ b/wsnet2-dashboard/backend/README.md
@@ -18,7 +18,7 @@ It provides APIs of `GraphQL` and `GRPC` for the dashboard.
 It is necessary to start `db`, as the schema is generated from the database.
 
 ```bash
-docker compose -f server/docker-compose.yml up -d db
+docker compose -f server/compose.yaml up -d db
 cd wsnet2-dashboard
 docker compose run --rm backend make
 ```

--- a/wsnet2-dashboard/compose.yaml
+++ b/wsnet2-dashboard/compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 name: wsnet2
 services:
   frontbuilder:


### PR DESCRIPTION
- compose.yamlが推奨されているのでリネーム
  - https://docs.docker.com/compose/compose-file/#compose-file
  - `version`も非推奨なので削除
  - ドキュメントも合わせて修正
- wait-for-it をやめ healthcheck ベースの depends_on を使うように変更
  - https://github.com/KLab/wsnet2/pull/16#discussion_r1093125091
  - dashboardはwait-for-itのまま
    - https://github.com/superkerokero/wsnet2/pull/1#discussion_r1098222683