### PR TITLE
ファイルへのログ出力の時刻フォーマットをRFC3339形式に変更

### DIFF
--- a/server/log/log.go
+++ b/server/log/log.go
@@ -181,6 +181,7 @@ func InitLogger(logconf *config.LogConf) func() {
 			ljackLogger.Close()
 		}
 		conf := zap.NewProductionEncoderConfig()
+		conf.EncodeTime = zapcore.RFC3339NanoTimeEncoder
 		core2 := zapcore.NewCore(zapcore.NewJSONEncoder(conf), sink, zap.DebugLevel)
 		core = zapcore.NewTee(core, core2)
 	}


### PR DESCRIPTION
unixtimeのままでは読みにくいのでRFC3339形式(小数部付き)にしました
このような形式です:
```
{"level":"info","ts":"2023-04-28T04:52:30.552917376Z","caller":"service/api.go:43","msg":"lobby api: \"tcp\" \":8080\"","host":"c8268da8b499","version":"v0.2.0-2-g76423f4"}
```