### PR TITLE
Hubが部屋終了後も接続リトライしていたのを修正

### DIFF
--- a/server/client/connection.go
+++ b/server/client/connection.go
@@ -252,7 +252,7 @@ func (conn *Connection) receiver(ctx context.Context, ws *websocket.Conn, starts
 		ws.SetReadDeadline(time.Now().Add(time.Duration(conn.deadline.Load()) * time.Second))
 		_, data, err := ws.ReadMessage()
 		if err != nil {
-			return xerrors.Errorf("receiver read: %w", err)
+			return err // websocket.IsCloseError()がwrapを考慮してくれないのでこのまま返す
 		}
 
 		ev, seq, err := binary.UnmarshalEvent(data)

--- a/server/hub/hub.go
+++ b/server/hub/hub.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -56,9 +57,10 @@ func NewHub(repo *Repository, pk int64, appid AppID, roomid RoomID, grpc *grpc.C
 
 	ctx := context.Background() // hubの寿命はリクエストなどに紐付かない
 
+	lg := logger.WithOptions(zap.AddCallerSkip(1))
 	room, conn, err := client.WatchDirect(
 		ctx, grpc, wsHost, appid, string(roomid), clinfo,
-		func(err error) { logger.Warnf("%v: %v", clientid, err) })
+		func(err error) { lg.Warnf("%v: %v", clientid, err) })
 	if err != nil {
 		return nil, xerrors.Errorf("client.WatchDirect: %w", err)
 	}


### PR DESCRIPTION
websocket.IsCloseError()がerrorのwrapを考慮してくれなかったので、正常終了を正しく判定できていませんでした。