### PR TITLE
送信失敗したときh.lastNodeCountは更新してはいけない

### DIFF
--- a/server/hub/hub.go
+++ b/server/hub/hub.go
@@ -183,8 +183,9 @@ func (h *Hub) nodeCountUpdater() {
 			case h.nodeCountUpdated <- struct{}{}:
 			default:
 			}
+		} else {
+			h.lastNodeCount = count
 		}
-		h.lastNodeCount = count
 
 		select {
 		case <-h.Done():


### PR DESCRIPTION
次のタイミングでリトライするために `nodeCountUpdated` チャネルに通知投げ込んでいるのに、
`lastNodeCount` を更新してしまっていたので、変更なしとして送信してくれないコードになってました。