### PR TITLE
UnityではLobbyへの通信にUnityWebRequestを使う

### DIFF
--- a/wsnet2-unity/Assets/WSNet2/Scripts/Core/Connection.cs
+++ b/wsnet2-unity/Assets/WSNet2/Scripts/Core/Connection.cs
@@ -118,14 +118,10 @@ namespace WSNet2
                     reconnectLimit = null;
                     room.ConnectionStateChanged(true);
 
-                    var tasks = new Task[]
-                    {
-                        Task.Run(async() => await Receiver(ws, cts.Token)),
-                        Task.Run(async() => await await senderTaskSource.Task),
-                        Task.Run(async() => await await pingerTaskSource.Task),
-                    };
-
-                    await tasks[Task.WaitAny(tasks)];
+                    await await Task.WhenAny(
+                        Task.Run(async () => await Receiver(ws, cts.Token)),
+                        Task.Run(async () => await await senderTaskSource.Task),
+                        Task.Run(async () => await await pingerTaskSource.Task));
 
                     // finish task without exception: unreconnectable. don't retry.
                     return;

--- a/wsnet2-unity/Assets/WSNet2/Scripts/Core/DefaultHttpClient.cs
+++ b/wsnet2-unity/Assets/WSNet2/Scripts/Core/DefaultHttpClient.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace WSNet2
+{
+    /// <summary>
+    ///   System.Net.Http.HttpClientを使ったPOSTの実装
+    /// </summary>
+    static class DefaultHttpClient
+    {
+        static HttpClient client;
+
+        public static void Post(string url, IReadOnlyDictionary<string, string> headers, byte[] content, TaskCompletionSource<(int, byte[])> tcs)
+        {
+            Task.Run(async () =>
+            {
+                try
+                {
+                    var request = new HttpRequestMessage(HttpMethod.Post, url);
+                    request.Content = new ByteArrayContent(content);
+                    foreach (var kv in headers)
+                    {
+                        request.Headers.Add(kv.Key, kv.Value);
+                    }
+
+                    client ??= new HttpClient();
+                    var res = await client.SendAsync(request);
+                    var body = await res.Content.ReadAsByteArrayAsync();
+
+                    tcs.TrySetResult(((int)res.StatusCode, body));
+                }
+                catch (Exception e)
+                {
+                    tcs.TrySetException(e);
+                }
+            });
+        }
+    }
+}

--- a/wsnet2-unity/Assets/WSNet2/Scripts/Core/DefaultHttpClient.cs.meta
+++ b/wsnet2-unity/Assets/WSNet2/Scripts/Core/DefaultHttpClient.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 886b717e439330ff9aaa0f7644aae00c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/wsnet2-unity/Assets/WSNet2/Scripts/WSNet2Service.cs
+++ b/wsnet2-unity/Assets/WSNet2/Scripts/WSNet2Service.cs
@@ -33,6 +33,7 @@ namespace WSNet2
         Dictionary<string, WSNet2Client> clients;
         Dictionary<string, WSNet2Client> newClients;
         Action doOnUpdate;
+        Object doOnUpdateLock;
 
         IWSNet2Logger<WSNet2LogPayload> defaultLogger;
 
@@ -42,6 +43,7 @@ namespace WSNet2
             newClients = new Dictionary<string, WSNet2Client>();
             DontDestroyOnLoad(this.gameObject);
             defaultLogger = new DefaultUnityLogger();
+            doOnUpdateLock = new Object();
         }
 
         /// <summary>
@@ -90,7 +92,7 @@ namespace WSNet2
                 cli.ProcessCallback();
             }
 
-            lock (this)
+            lock (doOnUpdateLock)
             {
                 doOnUpdate?.Invoke();
                 doOnUpdate = null;
@@ -119,7 +121,7 @@ namespace WSNet2
 
         void httpPost(string url, IReadOnlyDictionary<string, string> headers, byte[] content, TaskCompletionSource<(int, byte[])> tcs)
         {
-            lock (this)
+            lock (doOnUpdateLock)
             {
                 doOnUpdate += () => StartCoroutine(doPost(url, headers, content, tcs));
             }


### PR DESCRIPTION
いままで[HttpClient](https://learn.microsoft.com/ja-jp/dotnet/api/system.net.http.httpclient?view=net-7.0)を使っていましたが、Unityでは[UnityWebRequest](https://docs.unity3d.com/ja/2020.3/ScriptReference/Networking.UnityWebRequest.html)を使ったほうが良いとのことなので、
WSNet2Clientで差し替えられるようにして、UnityでWSNet2Service経由で使う時は差し替えるようにしました。
くわえて、HttpClientも毎回newしてしまっていたのを修正しました。