### PR TITLE
HubからのNodeCount送信が極稀にエラーとして記録されていたので対処

### DIFF
--- a/server/client/connection.go
+++ b/server/client/connection.go
@@ -356,12 +356,25 @@ func (conn *Connection) sender(ctx context.Context, ws *websocket.Conn, mu *sync
 }
 
 func (conn *Connection) systemSender(ctx context.Context, ws *websocket.Conn, mu *sync.Mutex) error {
+	// 送信中の投げ込みも受け付けるようcap=1のチャネルを挟む
+	mc := make(chan binary.Msg, 1)
+	// systemSenderが動き始めてからsysmsgへの書き込みを受け付ける (see: conn.SendSystemMsg())
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case mc <- <-conn.sysmsg:
+			}
+		}
+	}()
+
 	for {
 		var msg binary.Msg
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case msg = <-conn.sysmsg:
+		case msg = <-mc:
 		}
 
 		conn.mumsg.Lock()

--- a/server/hub/hub.go
+++ b/server/hub/hub.go
@@ -176,7 +176,7 @@ func (h *Hub) nodeCountUpdater() {
 
 		h.repo.updateHubWatchers(h, int(count))
 		if err := h.conn.SendSystemMsg(binary.NewMsgNodeCount(count)); err != nil {
-			h.logger.Errorf("send nodecount: %+v", err)
+			h.logger.Infof("send nodecount: %v", err)
 
 			// retry after interval
 			select {


### PR DESCRIPTION
接続と入室が別管理なため、入室してすぐNodeCountを送信しようとしたとき、
タイミングによってはまだ接続していないため送信がエラーになるケースがありました。
正常動作の範囲なのでログレベルを変更しました。

また別のメッセージ送信中にNodeCountを送信しようとしたときにも同様のエラーが起こり得るので、
容量付きチャネルを挟むことでこのエラーが起こりにくいようにしました。
NodeCount送信同士はintervalを挟むのでcap=1で十分なはずです。