### PR TITLE
WebSocket接続するときのHTTPエラーの処理を修正

### DIFF
--- a/server/client/connection.go
+++ b/server/client/connection.go
@@ -228,7 +228,7 @@ func (conn *Connection) connect(ctx context.Context, warn func(error)) (string, 
 			return err.(*websocket.CloseError).Text, nil
 		}
 		if ue := unrecoverable(nil); errors.As(err, &ue) {
-			return "give up reconnecting", ue.Unwrap()
+			return "give up on reconnection", ue.Unwrap()
 		}
 
 		warn(err)

--- a/server/game/service/websocket.go
+++ b/server/game/service/websocket.go
@@ -100,21 +100,21 @@ func (s *WSHandler) HandleRoom(w http.ResponseWriter, r *http.Request) {
 	lastEvSeq, err := strconv.Atoi(r.Header.Get("Wsnet2-LastEventSeq"))
 	if err != nil {
 		logger.Infof("websocket: invalid header: LastEventSeq=%v, %+v", r.Header.Get("Wsnet2-LastEventSeq"), err)
-		http.Error(w, "Bad Request", 400)
+		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
 	}
 
 	repo, ok := s.repos[appId]
 	if !ok {
 		logger.Infof("websocket: invalid appId: %v", appId)
-		http.Error(w, "Bad Request", 400)
+		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
 	}
 
 	cli, err := repo.GetClient(roomId, clientId)
 	if err != nil {
-		logger.Infof("websocket: repo.GetClient: %+v", err)
-		http.Error(w, "Bad Request", 400)
+		logger.Infof("websocket: repo.GetClient: %v", err)
+		http.Error(w, "Not Found", http.StatusNotFound)
 		return
 	}
 	logger.Infof("websocket: room=%v client=%v", roomId, clientId)

--- a/wsnet2-unity/Assets/WSNet2/Scripts/Core/Connection.cs
+++ b/wsnet2-unity/Assets/WSNet2/Scripts/Core/Connection.cs
@@ -126,21 +126,6 @@ namespace WSNet2
                     // finish task without exception: unreconnectable. don't retry.
                     return;
                 }
-                catch (WebSocketException e)
-                {
-                    logger?.Error(e, "websocket exception: {0}", e);
-                    switch (e.WebSocketErrorCode)
-                    {
-                        case WebSocketError.NotAWebSocket:
-                        case WebSocketError.UnsupportedProtocol:
-                        case WebSocketError.UnsupportedVersion:
-                            // unnable to connect. don't retry.
-                            throw;
-                    }
-
-                    // retry on other error.
-                    lastException = e;
-                }
                 catch (Exception e)
                 {
                     logger?.Error(e, "connection exception: {0}", e);
@@ -165,7 +150,7 @@ namespace WSNet2
 
                 if (DateTime.Now > reconnectLimit)
                 {
-                    throw new Exception($"MaxReconnection: {lastException.Message}", lastException);
+                    throw new Exception($"Gave up on Reconnection: {lastException.Message}", lastException);
                 }
 
                 room.handleError(lastException);


### PR DESCRIPTION
Unityのときだけ、Clientが部屋に居なかったときにも再接続リトライをし続けていました。
打ち切るようにしたかったのですが、HTTPのエラーかどうか判別する手段がありませんでした。[Unityでの例外生成部分](https://github.com/Unity-Technologies/corefx/blob/1011665e56d38aa482c2d596db40809f5e40064d/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs#L329)
.NETではErrorCodeがNotAWebSocketになっていて判別できていました。

ただ.NETでもレスポンスコードまでは(エラーメッセージを解析する以外では)取れなかったので、
40xは打ち切りたいけど502はリトライなどに対処できないため、
たとえ退室済みだったとしても一律でリトライするようにしました。