### PR TITLE
部屋番号0の検索ではRoomNotFoundExceptionを返す

### DIFF
--- a/wsnet2-unity/Assets/WSNet2/Scripts/Core/WSNet2Client.cs
+++ b/wsnet2-unity/Assets/WSNet2/Scripts/Core/WSNet2Client.cs
@@ -215,7 +215,7 @@ namespace WSNet2
 
             if (number == 0)
             {
-                callbackPool.Add(() => onFailed(new Exception("Room number cannot be 0")));
+                callbackPool.Add(() => onFailed(new RoomNotFoundException("Room number cannot be 0")));
                 return;
             }
 
@@ -310,7 +310,7 @@ namespace WSNet2
 
             if (number == 0)
             {
-                callbackPool.Add(() => onFailed(new Exception("Room number cannot be 0")));
+                callbackPool.Add(() => onFailed(new RoomNotFoundException("Room number cannot be 0")));
                 return;
             }
 


### PR DESCRIPTION
互換性を維持するためRoomNotFoundを返すことにします。
部屋番号0が絶対に無いのはWSNet2側の都合(仕様)なので、利用者がそれを知らなくても自然に使えるという意図もあります。