### PR TITLE
C#で再接続リトライをし続けてしまう問題の修正

### DIFF
--- a/wsnet2-unity/Assets/WSNet2/Scripts/Core/Connection.cs
+++ b/wsnet2-unity/Assets/WSNet2/Scripts/Core/Connection.cs
@@ -18,6 +18,7 @@ namespace WSNet2
         public MsgPool msgPool { get; private set; }
 
         CancellationTokenSource canceller;
+        DateTime reconnectLimit;
 
         Room room;
         string appId;
@@ -46,6 +47,7 @@ namespace WSNet2
         {
             this.logger = logger;
             this.canceller = new CancellationTokenSource();
+            this.reconnectLimit = DateTime.Now.AddSeconds(room.ClientDeadline);
             this.room = room;
             this.appId = joined.roomInfo.appId;
             this.clientId = clientId;
@@ -87,7 +89,7 @@ namespace WSNet2
         /// </remarks>
         public async Task Start()
         {
-            DateTime? reconnectLimit = null;
+            bool connected = false;
             int reconnection = 0;
 
             while (true)
@@ -109,13 +111,8 @@ namespace WSNet2
 
                 try
                 {
-                    if (reconnectLimit == null)
-                    {
-                        reconnectLimit = DateTime.Now.AddSeconds(room.ClientDeadline);
-                    }
-
-                    var ws = await Connect(cts.Token);
-                    reconnectLimit = null;
+                    using var ws = await Connect(cts.Token);
+                    connected = true;
                     room.ConnectionStateChanged(true);
 
                     await await Task.WhenAny(
@@ -128,7 +125,7 @@ namespace WSNet2
                 }
                 catch (Exception e)
                 {
-                    logger?.Error(e, "connection exception: {0}", e);
+                    logger?.Warning(e, "connection exception: {0}", e);
                     // retry
                     lastException = e;
                 }
@@ -137,8 +134,9 @@ namespace WSNet2
                     senderTaskSource.TrySetCanceled();
                     pingerTaskSource.TrySetCanceled();
                     cts.Cancel();
-                    if (reconnectLimit == null) // 接続成功している
+                    if (connected)
                     {
+                        connected = false;
                         room.ConnectionStateChanged(false);
                     }
                 }
@@ -158,7 +156,7 @@ namespace WSNet2
                 await retryInterval;
 
                 reconnection++;
-                logger?.Info("reconnect now:{0}, limit:{1}, count:{2}", DateTime.Now, reconnectLimit?.ToString() ?? "null", reconnection);
+                logger?.Info("reconnect now:{0}, limit:{1}, count:{2}", DateTime.Now, reconnectLimit, reconnection);
             }
         }
 
@@ -220,6 +218,8 @@ namespace WSNet2
                     ct.ThrowIfCancellationRequested();
                     var ev = await ReceiveEvent(ws, ct);
 
+                    this.reconnectLimit = DateTime.Now.AddSeconds(room.ClientDeadline);
+
                     if (ev.IsRegular)
                     {
                         if (ev.SequenceNum != evSeqNum + 1)
@@ -233,6 +233,11 @@ namespace WSNet2
 
                     switch (ev.Type)
                     {
+                        case EvType.Closed:
+                            // 正常終了。もう再接続しない。
+                            room.handleEvent(ev);
+                            return;
+
                         case EvType.PeerReady:
                             var evpr = ev as EvPeerReady;
                             logger?.Info("receive peer-ready: lastMsgSeqNum={0}", evpr.LastMsgSeqNum);
@@ -241,9 +246,6 @@ namespace WSNet2
                             senderTaskSource.TrySetResult(sender);
                             pingerTaskSource.TrySetResult(pinger);
                             break;
-                        case EvType.Closed:
-                            room.handleEvent(ev);
-                            return;
                         case EvType.Pong:
                             onPong(ev as EvPong);
                             room.handleEvent(ev);
@@ -320,24 +322,21 @@ namespace WSNet2
         /// <param name="ct">ループ停止するトークン</param>
         private async Task Sender(ClientWebSocket ws, int seqNum, CancellationToken ct)
         {
-            try
+            while (true)
             {
-                while (true)
-                {
-                    msgPool.Wait(ct);
+                msgPool.Wait(ct);
 
-                    ArraySegment<byte>? msg;
-                    while ((msg = msgPool.Take(seqNum)).HasValue)
+                ArraySegment<byte>? msg;
+                while ((msg = msgPool.Take(seqNum)).HasValue)
+                {
+                    if (ct.IsCancellationRequested)
                     {
-                        ct.ThrowIfCancellationRequested();
-                        await Send(ws, msg.Value, ct);
-                        seqNum++;
+                        return; // ctのキャンセルで終了
                     }
+
+                    await Send(ws, msg.Value, ct);
+                    seqNum++;
                 }
-            }
-            catch (OperationCanceledException)
-            {
-                // ctのキャンセルはループを抜けて終了
             }
         }
 
@@ -348,34 +347,30 @@ namespace WSNet2
         {
             var msg = new MsgPing(hmac);
 
-            try
+            while (true)
             {
-                while (true)
+                if (ct.IsCancellationRequested)
                 {
-                    ct.ThrowIfCancellationRequested();
+                    return; // ctのキャンセルで終了
+                }
 
-                    var interval = Task.Delay(pingInterval, pingerDelayCanceller.Token);
-                    var time = (uint)msg.SetTimestamp();
-                    lastPingTime = time;
-                    await Send(ws, msg.Value, ct);
-                    try
+                var interval = Task.Delay(pingInterval, pingerDelayCanceller.Token);
+                var time = (uint)msg.SetTimestamp();
+                lastPingTime = time;
+                await Send(ws, msg.Value, ct);
+                try
+                {
+                    await interval;
+                    // 対応するPongが返ってきていたらlastPingTimeは書き換わっている
+                    if (lastPingTime == time)
                     {
-                        await interval;
-                        // 対応するPongが返ってきていたらlastPingTimeは書き換わっている
-                        if (lastPingTime == time)
-                        {
-                            throw new Exception("Pong unreceived");
-                        }
-                    }
-                    catch (TaskCanceledException)
-                    {
-                        // pingerDelayCancellerによるcancelは無視
+                        throw new Exception("Pong unreceived");
                     }
                 }
-            }
-            catch (OperationCanceledException)
-            {
-                // ctのキャンセルはループを抜けて終了
+                catch (TaskCanceledException)
+                {
+                    // pingerDelayCancellerによるcancelは無視
+                }
             }
         }
 


### PR DESCRIPTION
websocketの接続に成功した時点でreconnectLimitを更新してしまうため、
Upgrade直後にエラーになる場合、ClientDeadlineを超えて無駄に再接続リトライしてしまうので修正しました。
また、websocketのSendもTaskCanceledExceptionを投げうるので合わせて対策しました。