### PR TITLE
UnityEngine.Debug.LogExceptionはErrorレベルのときのみ呼び出す

### DIFF
--- a/wsnet2-unity/Assets/WSNet2/Scripts/DefaultUnityLogger.cs
+++ b/wsnet2-unity/Assets/WSNet2/Scripts/DefaultUnityLogger.cs
@@ -18,20 +18,27 @@ namespace WSNet2
                 case WSNet2LogLevel.Critical:
                 case WSNet2LogLevel.Error:
                     UnityEngine.Debug.LogError(msg);
+                    if (exception != null)
+                    {
+                        UnityEngine.Debug.LogException(exception);
+                    }
                     break;
                 case WSNet2LogLevel.Warning:
+                    if (exception != null)
+                    {
+                        msg = $"{msg}: {exception.Message}";
+                    }
                     UnityEngine.Debug.LogWarning(msg);
                     break;
                 case WSNet2LogLevel.Information:
                 case WSNet2LogLevel.Debug:
                 case WSNet2LogLevel.Trace:
+                    if (exception != null)
+                    {
+                        msg = $"{msg}: {exception.Message}";
+                    }
                     UnityEngine.Debug.Log(msg);
                     break;
-            }
-
-            if (exception != null)
-            {
-                UnityEngine.Debug.LogException(exception);
             }
         }
     }


### PR DESCRIPTION
INFOレベルで出すのはノイズになってしまうので。