### PR TITLE
PlayerLogで退室理由がわかるように

### DIFF
--- a/server/game/repository.go
+++ b/server/game/repository.go
@@ -515,12 +515,15 @@ func (repo *Repository) adminKickRoom(room *Room, userID string) error {
 type PlayerLogMsg string
 
 const (
-	PlayerLogCreate PlayerLogMsg = "Create"
-	PlayerLogJoin   PlayerLogMsg = "Join"
-	PlayerLogRejoin PlayerLogMsg = "Rejoin"
-	PlayerLogLeave  PlayerLogMsg = "Leave"
-	PlayerLogAttach PlayerLogMsg = "Attach"
-	PlayerLogDetach PlayerLogMsg = "Detach"
+	PlayerLogCreate  PlayerLogMsg = "Create"
+	PlayerLogJoin    PlayerLogMsg = "Join"
+	PlayerLogRejoin  PlayerLogMsg = "Rejoin"
+	PlayerLogLeave   PlayerLogMsg = "Leave"
+	PlayerLogTimeout PlayerLogMsg = "Timeout"
+	PlayerLogKick    PlayerLogMsg = "Kick"
+	PlayerLogError   PlayerLogMsg = "Error"
+	PlayerLogAttach  PlayerLogMsg = "Attach"
+	PlayerLogDetach  PlayerLogMsg = "Detach"
 )
 
 func (repo *Repository) PlayerLog(c *Client, msg PlayerLogMsg) {


### PR DESCRIPTION
`player_log`テーブルの退室メッセージがすべて`Leave`だったのを、
理由に応じて `Timeout`, `Kick`, `Error` となるようにしました。