### PR TITLE
game/hubのgRPC正常系エラーハンドリング修正

### DIFF
--- a/server/game/errors.go
+++ b/server/game/errors.go
@@ -1,6 +1,7 @@
 package game
 
 import (
+	"errors"
 	"fmt"
 
 	"golang.org/x/xerrors"
@@ -11,22 +12,40 @@ import (
 type ErrorWithCode interface {
 	error
 	Code() codes.Code
+	IsNormal() bool
 }
 
 type errorWithCode struct {
 	error
-	code codes.Code
+	code     codes.Code
+	isNormal bool
 }
 
 func WithCode(err error, code codes.Code) ErrorWithCode {
 	if err == nil {
 		return nil
 	}
-	return errorWithCode{err, code}
+	var ewc ErrorWithCode
+	if errors.As(err, &ewc) {
+		return errorWithCode{err, code, ewc.IsNormal()}
+	}
+
+	return errorWithCode{err, code, false}
+}
+
+func NormalWithCode(err error, code codes.Code) ErrorWithCode {
+	if err == nil {
+		return nil
+	}
+	return errorWithCode{err, code, true}
 }
 
 func (e errorWithCode) Code() codes.Code {
 	return e.code
+}
+
+func (e errorWithCode) IsNormal() bool {
+	return e.isNormal
 }
 
 func (e errorWithCode) Unwrap() error {

--- a/server/game/repository.go
+++ b/server/game/repository.go
@@ -223,7 +223,7 @@ func (repo *Repository) joinRoom(ctx context.Context, id string, client *pb.Clie
 
 	room, err := repo.GetRoom(id)
 	if err != nil {
-		return nil, WithCode(xerrors.Errorf("repo.GetRoom: %w", err), codes.NotFound)
+		return nil, NormalWithCode(xerrors.Errorf("repo.GetRoom: %w", err), codes.NotFound)
 	}
 
 	jch := make(chan *JoinedInfo, 1)
@@ -433,7 +433,7 @@ func (repo *Repository) GetRoomInfo(ctx context.Context, id string) (*pb.GetRoom
 
 	room, err := repo.GetRoom(id)
 	if err != nil {
-		return nil, WithCode(xerrors.Errorf("GetRoomInfo: %w", err), codes.NotFound)
+		return nil, NormalWithCode(xerrors.Errorf("GetRoomInfo: %w", err), codes.NotFound)
 	}
 
 	ch := make(chan *pb.GetRoomInfoRes, 1)
@@ -462,7 +462,7 @@ func (repo *Repository) AdminKick(ctx context.Context, roomID, userID string, lo
 	if roomID != "" {
 		room, err := repo.GetRoom(roomID)
 		if err != nil {
-			return WithCode(xerrors.Errorf("AdminKick: can not find room %q; %w", roomID, err), codes.NotFound)
+			return NormalWithCode(xerrors.Errorf("AdminKick: can not find room %q; %w", roomID, err), codes.NotFound)
 		}
 
 		return repo.adminKickRoom(room, userID)

--- a/server/game/service/grpc.go
+++ b/server/game/service/grpc.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"wsnet2/game"
 	"wsnet2/log"
 	"wsnet2/pb"
 )
@@ -68,7 +69,7 @@ func (sv *GameService) Create(ctx context.Context, in *pb.CreateRoomReq) (*pb.Jo
 
 	res, err := repo.CreateRoom(ctx, in.RoomOption, in.MasterInfo, in.MacKey)
 	if err != nil {
-		logger.Errorf("repo.CreateRoom: %+v", err)
+		logEWC(logger, "repo.CreateRoom", err)
 		return nil, status.Errorf(err.Code(), "CreateRoom failed: %s", err)
 	}
 
@@ -109,7 +110,7 @@ func (sv *GameService) Join(ctx context.Context, in *pb.JoinRoomReq) (*pb.Joined
 
 	res, err := repo.JoinRoom(ctx, in.RoomId, in.ClientInfo, in.MacKey)
 	if err != nil {
-		logger.Errorf("repo.JoinRoom: %+v", err)
+		logEWC(logger, "repo.JoinRoom", err)
 		return nil, status.Errorf(err.Code(), "JoinRoom failed: %s", err)
 	}
 
@@ -138,7 +139,7 @@ func (sv *GameService) Watch(ctx context.Context, in *pb.JoinRoomReq) (*pb.Joine
 
 	res, err := repo.WatchRoom(ctx, in.RoomId, in.ClientInfo, in.MacKey)
 	if err != nil {
-		logger.Errorf("repo.WatchRoom: %+v", err)
+		logEWC(logger, "repo.WatchRoom", err)
 		return nil, status.Errorf(err.Code(), "WatchRoom failed: %s", err)
 	}
 
@@ -196,4 +197,12 @@ func (sv *GameService) Kick(ctx context.Context, in *pb.KickReq) (*pb.Empty, err
 	logger.Infof("gRPC Kick OK: room=%q user=%q", in.RoomId, in.ClientId)
 
 	return &pb.Empty{}, nil
+}
+
+func logEWC(logger log.Logger, msg string, err game.ErrorWithCode) {
+	if err.IsNormal() {
+		logger.Infof("%s: %v", msg, err)
+	} else {
+		logger.Errorf("%s: %+v", msg, err)
+	}
 }

--- a/server/hub/hub.go
+++ b/server/hub/hub.go
@@ -285,15 +285,13 @@ func (h *Hub) broadcast(ev *binary.RegularEvent) {
 func (h *Hub) msgWatch(msg *game.MsgWatch) {
 	if !h.room.Watchable {
 		err := xerrors.Errorf("Room is not watchable. room=%v, client=%v", h.ID(), msg.Info.Id)
-		h.logger.Info(err.Error())
-		msg.Err <- game.WithCode(err, codes.FailedPrecondition)
+		msg.Err <- game.NormalWithCode(err, codes.FailedPrecondition)
 		return
 	}
 
 	// Playerとして参加中の観戦は不許可
 	if _, ok := h.room.Players[string(msg.SenderID())]; ok {
 		err := xerrors.Errorf("Watcher already exists as a player. room=%v, client=%v", h.ID(), msg.SenderID())
-		h.logger.Warn(err.Error())
 		msg.Err <- game.WithCode(err, codes.AlreadyExists)
 		return
 	}
@@ -303,7 +301,6 @@ func (h *Hub) msgWatch(msg *game.MsgWatch) {
 		err = game.WithCode(
 			xerrors.Errorf("NewWatcher error. room=%v, client=%v: %w", h.ID(), msg.Info.Id, err),
 			err.Code())
-		h.logger.Warn(err.Error())
 		msg.Err <- err
 		return
 	}

--- a/server/hub/repository.go
+++ b/server/hub/repository.go
@@ -155,7 +155,7 @@ func (r *Repository) WatchRoom(ctx context.Context, appId AppID, roomId RoomID, 
 	}
 	select {
 	case <-hub.Done():
-		return nil, game.WithCode(
+		return nil, game.NormalWithCode(
 			xerrors.Errorf("hub closed: room=%v client=%v", roomId, client.Id),
 			codes.NotFound)
 	case <-ctx.Done():
@@ -168,7 +168,7 @@ func (r *Repository) WatchRoom(ctx context.Context, appId AppID, roomId RoomID, 
 	var joined *game.JoinedInfo
 	select {
 	case <-hub.Done():
-		return nil, game.WithCode(
+		return nil, game.NormalWithCode(
 			xerrors.Errorf("hub closed: room=%v client=%v", roomId, client.Id),
 			codes.NotFound)
 	case <-ctx.Done():

--- a/server/hub/service/grpc.go
+++ b/server/hub/service/grpc.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
 
+	"wsnet2/game"
 	"wsnet2/hub"
 	"wsnet2/log"
 	"wsnet2/pb"
@@ -62,7 +63,7 @@ func (sv *HubService) Watch(ctx context.Context, in *pb.JoinRoomReq) (*pb.Joined
 
 	res, err := sv.repo.WatchRoom(ctx, in.AppId, hub.RoomID(in.RoomId), in.ClientInfo, in.GrpcHost, in.WsHost, in.MacKey)
 	if err != nil {
-		logger.Errorf("repo.WatchRoom: %+v", err)
+		logEWC(logger, "repo.WatchRoom", err)
 		return nil, status.Errorf(err.Code(), "WatchRoom failed: %s", err)
 	}
 
@@ -71,4 +72,12 @@ func (sv *HubService) Watch(ctx context.Context, in *pb.JoinRoomReq) (*pb.Joined
 	logger.Infof("gRPC Watch OK: room=%v user=%v", res.RoomInfo.Id, in.ClientInfo.Id)
 
 	return res, nil
+}
+
+func logEWC(logger log.Logger, msg string, err game.ErrorWithCode) {
+	if err.IsNormal() {
+		logger.Infof("%s: %v", msg, err)
+	} else {
+		logger.Errorf("%s: %+v", msg, err)
+	}
 }


### PR DESCRIPTION
正常系エラーのログをErrorではなくInfoに、またログが重複しないようにしました。

正常系エラー：
- 入室/観戦リクエスト時に部屋がすでに終了していたとき
- joinable/watchableフラグが無効のとき
- maxPlayersに達していたとき