### PR TITLE
現在入室中の部屋一覧を取得するAPI

### DIFF
--- a/_doc/wsnet2client.md
+++ b/_doc/wsnet2client.md
@@ -15,6 +15,7 @@
   - [Watch(number)](#watchnumber)
 - [部屋検索](#部屋検索)
   - [Search](#search)
+  - [CurrentRooms](#currentrooms)
 
 ## 概要
 WSNet2へのアクセスは、[`WSNet2.WSNet2Client`](../wsnet2-unity/Assets/WSNet2/Scripts/Core/WSNet2Client.cs)クラスを利用します。
@@ -216,3 +217,21 @@ void Search(
 - `checkWatchable`: true: 観戦可能な部屋のみ含める
 - `onSuccess`: 成功時コールバック。引数はRoom一覧
 - `onFailed`: 失敗時コールバック。引数は例外オブジェクト
+
+### CurrentRooms
+
+```C#
+void CurrentRooms(
+    Query query,
+    Action<PublicRoom[]> onSuccess,
+    Action<Exception> onFailed);
+```
+
+自分自身がPlayerとして入室中のRoom一覧を取得します。
+
+- `query`: 部屋条件クエリ
+- `onSuccess`: 成功時コールバック。引数はRoom一覧
+- `onFailed`: 失敗時コールバック。引数は例外オブジェクト
+
+観戦中のRoomは含みません。
+結果のRoomは作成時刻順に昇順ソートされています。

--- a/server/client/request.go
+++ b/server/client/request.go
@@ -145,9 +145,19 @@ func WatchDirect(ctx context.Context, grpccon *grpc.ClientConn, wshost, appid, r
 	return connectToRoom(ctx, accinfo, res, warn)
 }
 
-// Search 部屋を検索する
+// Search : 部屋を検索する
 func Search(ctx context.Context, accinfo *AccessInfo, param *lobby.SearchParam) ([]*pb.RoomInfo, error) {
 	res, err := lobbyRequest(ctx, accinfo, "/rooms/search", param)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Rooms, nil
+}
+
+// Current : 現在入室しているRoomInfo一覧を取得する
+func Current(ctx context.Context, accinfo *AccessInfo, param *lobby.SearchCurrentRoomsParam) ([]*pb.RoomInfo, error) {
+	res, err := lobbyRequest(ctx, accinfo, "/rooms/search/current", param)
 	if err != nil {
 		return nil, err
 	}

--- a/server/cmd/wsnet2-bot/cmd/root.go
+++ b/server/cmd/wsnet2-bot/cmd/root.go
@@ -24,6 +24,7 @@ const (
 	ScenarioJoinRoomGroup    = 101
 	ScenarioMessageGroup     = 102
 	ScenarioKickGroup        = 103
+	ScenarioSearchCurrent    = 104
 
 	SoakSearchGroup = 200
 
@@ -195,4 +196,14 @@ func watchRoom(ctx context.Context, watcher, roomId string, query *client.Query)
 	}
 
 	return client.Watch(ctx, accinfo, roomId, query, nil)
+}
+
+// searchCurrent search current rooms
+func searchCurrent(ctx context.Context, cid string) ([]*pb.RoomInfo, error) {
+	accinfo, err := client.GenAccessInfo(lobbyURL, appId, appKey, cid)
+	if err != nil {
+		return nil, err
+	}
+
+	return client.Current(ctx, accinfo, &lobby.SearchCurrentRoomsParam{})
 }

--- a/server/game/repository.go
+++ b/server/game/repository.go
@@ -458,6 +458,24 @@ func (repo *Repository) GetRoomInfo(ctx context.Context, id string) (*pb.GetRoom
 	return res, nil
 }
 
+func (repo *Repository) GetCurrentRoomIds(ctx context.Context, clientId string) (*pb.RoomIdsRes, error) {
+	repo.mu.RLock()
+	defer repo.mu.RUnlock()
+
+	var ids []string
+	for rid, cli := range repo.clients[ClientID(clientId)] {
+		if cli.isPlayer {
+			ids = append(ids, string(rid))
+		}
+	}
+
+	res := &pb.RoomIdsRes{
+		RoomIds: ids,
+	}
+
+	return res, nil
+}
+
 func (repo *Repository) AdminKick(ctx context.Context, roomID, userID string, logger log.Logger) error {
 	if roomID != "" {
 		room, err := repo.GetRoom(roomID)

--- a/server/lobby/api_structs.go
+++ b/server/lobby/api_structs.go
@@ -36,6 +36,10 @@ type SearchByNumbersParam struct {
 	Queries     []PropQueries `json:"query"`
 }
 
+type SearchCurrentRoomsParam struct {
+	Queries []PropQueries `json:"query"`
+}
+
 type AdminKickParam struct {
 	TargetID string `json:"target_id"`
 }

--- a/server/pb/gameservice.proto
+++ b/server/pb/gameservice.proto
@@ -12,6 +12,7 @@ service Game {
 	rpc Join (JoinRoomReq) returns (JoinedRoomRes);
 	rpc Watch (JoinRoomReq) returns (JoinedRoomRes);
 	rpc GetRoomInfo (GetRoomInfoReq) returns (GetRoomInfoRes);
+	rpc CurrentRooms (CurrentRoomsReq) returns (RoomIdsRes);
 	rpc Kick (KickReq) returns (Empty);
 }
 
@@ -62,6 +63,15 @@ message GetRoomInfoRes {
 	repeated ClientInfo client_infos = 2;
 	string master_id = 3;
 	map<string, uint64> last_msg_times = 4;
+}
+
+message CurrentRoomsReq {
+	string app_id = 1;
+	string client_id = 2;
+}
+
+message RoomIdsRes {
+	repeated string room_ids = 1;
 }
 
 message KickReq {

--- a/wsnet2-unity/Assets/WSNet2/Scripts/Core/MessagePack/LobbyParams.cs
+++ b/wsnet2-unity/Assets/WSNet2/Scripts/Core/MessagePack/LobbyParams.cs
@@ -67,4 +67,11 @@ namespace WSNet2
         [Key("query")]
         public List<List<Query.Condition>> queries;
     }
+
+    [MessagePackObject]
+    public class SearchCurrentRoomsParam
+    {
+        [Key("query")]
+        public List<List<Query.Condition>> queries;
+    }
 }

--- a/wsnet2-unity/Assets/WSNet2/Scripts/Core/WSNet2Client.cs
+++ b/wsnet2-unity/Assets/WSNet2/Scripts/Core/WSNet2Client.cs
@@ -420,6 +420,17 @@ namespace WSNet2
             Task.Run(() => search("/rooms/search/numbers", content, onSuccess, onFailed));
         }
 
+        public void CurrentRooms(Query query, Action<PublicRoom[]> onSuccess, Action<Exception> onFailed)
+        {
+            var param = new SearchCurrentRoomsParam()
+            {
+                queries = query?.condsList,
+            };
+            var content = MessagePackSerializer.Serialize(param);
+
+            Task.Run(() => search("/rooms/search/current", content, onSuccess, onFailed));
+        }
+
         private async Task<LobbyResponse> post(string path, byte[] content)
         {
             var url = baseUri + path;


### PR DESCRIPTION
Client自身が現在入室中の部屋の一覧を取得できるようにしました。

- `/rooms/search/current`
- パラメータのQueryでフィルタリング（他のsearchと一緒）
- 観戦部屋は含まない
- 結果のリストは部屋の作成順に昇順ソート

実装について:

- DBだけからの取得は難しいので、各gameサーバに問い合わせています。
- 各gameサーバで直接RoomInfoを安全にコピーするには`MsgGetRoomInfo`を使わねばならないので、
  gameサーバからはRoomIDのみを返し、Lobbyで集約してDBからRoomInfoを取得しています。
- DBの負荷軽減のためソートはlobbyで行っています。
