### PR TITLE
botにテストシナリオ追加

### DIFF
--- a/server/cmd/wsnet2-bot/cmd/cover_test.go
+++ b/server/cmd/wsnet2-bot/cmd/cover_test.go
@@ -1,0 +1,206 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/jmoiron/sqlx"
+
+	"wsnet2/config"
+	gameserv "wsnet2/game/service"
+	hubserv "wsnet2/hub/service"
+	lobbyserv "wsnet2/lobby/service"
+	"wsnet2/log"
+)
+
+/*
+docker run -d --rm \
+  -v `pwd`/../../../sql/10-schema.sql:/docker-entrypoint-initdb.d/10-schema.sql \
+  -v `pwd`/../../../sql/90-docker.sql:/docker-entrypoint-initdb.d/90-docker.sql \
+  -e MYSQL_ROOT_PASSWORD=root \
+  -e MYSQL_DATABASE=wsnet2 \
+  -e MYSQL_USER=wsnet2 \
+  -e MYSQL_PASSWORD=wsnet2pass \
+  -p 3306:3306 mysql:8.0
+
+go test . -cover -coverprofile=cover.out \
+  -coverpkg=wsnet2/auth,wsnet2/binary,wsnet2/common,wsnet2/config,wsnet2/game,wsnet2/game/service,wsnet2/hub,wsnet2/hub/service,wsnet2/lobby,wsnet2/lobby/service,wsnet2/log,wsnet2/pb
+
+go tool cover -html=cover.out -o cover.html
+*/
+
+func TestMain(t *testing.T) {
+	conf := config.Config{
+		Db: config.DbConf{
+			Host:            "localhost",
+			Port:            3306,
+			DBName:          "wsnet2",
+			User:            "wsnet2",
+			Password:        "wsnet2pass",
+			ConnMaxLifetime: config.Duration(3 * time.Minute),
+		},
+		Game: config.GameConf{
+			Hostname:          "localhost",
+			PublicName:        "localhost",
+			GRPCPort:          19000,
+			WebsocketPort:     8000,
+			PprofPort:         0,
+			TLSCert:           "",
+			TLSKey:            "",
+			RetryCount:        5,
+			MaxRoomNum:        999,
+			MaxRooms:          100,
+			MaxClients:        100,
+			DefaultMaxPlayers: 10,
+			DefaultDeadline:   5,
+			DefaultLoglevel:   3,
+			HeartBeatInterval: config.Duration(2 * time.Second),
+			DbMaxConns:        0,
+			ClientConf: config.ClientConf{
+				EventBufSize:   128,
+				WaitAfterClose: config.Duration(30 * time.Second),
+				AuthKeyLen:     32,
+			},
+			LogConf: config.LogConf{
+				LogStdoutConsole: true,
+				LogStdoutLevel:   3,
+				LogPath:          "",
+				LogMaxSize:       0,
+				LogMaxBackups:    0,
+				LogMaxAge:        0,
+				LogCompress:      false,
+			},
+		},
+		Hub: config.HubConf{
+			Hostname:          "localhost",
+			PublicName:        "localhost",
+			GRPCPort:          19001,
+			WebsocketPort:     8001,
+			PprofPort:         0,
+			TLSCert:           "",
+			TLSKey:            "",
+			MaxClients:        100,
+			DefaultLoglevel:   3,
+			ValidHeartBeat:    config.Duration(5 * time.Second),
+			HeartBeatInterval: config.Duration(2 * time.Second),
+			NodeCountInterval: config.Duration(1 * time.Second),
+			DbMaxConns:        0,
+			ClientConf: config.ClientConf{
+				EventBufSize:   128,
+				WaitAfterClose: config.Duration(30 * time.Second),
+				AuthKeyLen:     32,
+			},
+			LogConf: config.LogConf{
+				LogStdoutConsole: true,
+				LogStdoutLevel:   3,
+				LogPath:          "",
+				LogMaxSize:       0,
+				LogMaxBackups:    0,
+				LogMaxAge:        0,
+				LogCompress:      false,
+			},
+		},
+		Lobby: config.LobbyConf{
+			Hostname:       "localhost",
+			UnixPath:       "",
+			Net:            "tcp",
+			Port:           8080,
+			PprofPort:      0,
+			Loglevel:       3,
+			ValidHeartBeat: config.Duration(5 * time.Second),
+			AuthDataExpire: config.Duration(time.Minute),
+			ApiTimeout:     config.Duration(5 * time.Second),
+			HubMaxWatchers: 100,
+			DbMaxConns:     0,
+			LogConf: config.LogConf{
+				LogStdoutConsole: true,
+				LogStdoutLevel:   3,
+				LogPath:          "",
+				LogMaxSize:       0,
+				LogMaxBackups:    0,
+				LogMaxAge:        0,
+				LogCompress:      false,
+			},
+		},
+	}
+
+	defer log.InitLogger(&conf.Lobby.LogConf)()
+	log.SetLevel(log.Level(conf.Lobby.Loglevel))
+	logger = log.Get(log.INFO)
+
+	db := sqlx.MustOpen("mysql", conf.Db.DSN())
+	db.SetConnMaxLifetime(time.Duration(conf.Db.ConnMaxLifetime))
+
+	lobby := must(lobbyserv.New(db, &conf.Lobby))
+	game := must(gameserv.New(db, &conf.Game))
+	hub := must(hubserv.New(db, &conf.Hub))
+
+	ctx := context.Background()
+	cerr := make(chan error, 4)
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	lbctx, lbcancel := context.WithCancel(ctx)
+	go func() {
+		err := lobby.Serve(lbctx)
+		t.Log("lobby", err)
+		cerr <- err
+		wg.Done()
+	}()
+	go func() {
+		err := game.Serve(ctx)
+		t.Log("game", err)
+		cerr <- err
+		wg.Done()
+	}()
+	go func() {
+		err := hub.Serve(ctx)
+		t.Log("hub", err)
+		cerr <- err
+		wg.Done()
+	}()
+
+	time.Sleep(time.Second * 5)
+
+	// do scenario
+	lobbyURL = "http://localhost:8080"
+	appId = "testapp"
+	appKey = "testapppkey"
+
+	for n, scenario := range scenarios {
+		err := scenario(ctx)
+		t.Log(n, err)
+		if err != nil {
+			cerr <- err
+			break
+		}
+	}
+
+	time.Sleep(time.Second * 5)
+
+	lbcancel()
+	game.Shutdown(ctx)
+	hub.Shutdown(ctx)
+
+	wg.Wait()
+	close(cerr)
+
+	errs := make([]error, 0, 4)
+	for e := range cerr {
+		errs = append(errs, e)
+	}
+	if err := errors.Join(errs...); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func must[T any](t T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return t
+}

--- a/server/cmd/wsnet2-bot/cmd/cover_test.go
+++ b/server/cmd/wsnet2-bot/cmd/cover_test.go
@@ -1,3 +1,5 @@
+//go:build scenariocoverage
+
 package cmd
 
 import (
@@ -27,7 +29,7 @@ docker run -d --rm \
   -e MYSQL_PASSWORD=wsnet2pass \
   -p 3306:3306 mysql:8.0
 
-go test . -cover -coverprofile=cover.out \
+go test . -cover -coverprofile=cover.out -tags scenariocoverage \
   -coverpkg=wsnet2/auth,wsnet2/binary,wsnet2/common,wsnet2/config,wsnet2/game,wsnet2/game/service,wsnet2/hub,wsnet2/hub/service,wsnet2/lobby,wsnet2/lobby/service,wsnet2/log,wsnet2/pb
 
 go tool cover -html=cover.out -o cover.html

--- a/server/cmd/wsnet2-bot/cmd/root.go
+++ b/server/cmd/wsnet2-bot/cmd/root.go
@@ -25,6 +25,8 @@ const (
 	ScenarioMessageGroup     = 102
 	ScenarioKickGroup        = 103
 	ScenarioSearchCurrent    = 104
+	ScenarioClientProp       = 105
+	ScenarioRejoin           = 106
 
 	SoakSearchGroup = 200
 

--- a/server/cmd/wsnet2-bot/cmd/scenario.go
+++ b/server/cmd/wsnet2-bot/cmd/scenario.go
@@ -31,19 +31,21 @@ var scenarioCmd = &cobra.Command{
 	},
 }
 
+var scenarios = map[string]func(context.Context) error{
+	"LobbySearch":   scenarioLobbySearch,
+	"JoinRoom":      scenarioJoinRoom,
+	"Message":       scenarioMessage,
+	"Kick":          scenarioKick,
+	"SearchCurrent": scenarioSearchCurrent,
+}
+
 func init() {
 	rootCmd.AddCommand(scenarioCmd)
 }
 
 // runScenario runs scenario test
 func runScenario(ctx context.Context) error {
-	for _, scenario := range []func(context.Context) error{
-		scenarioLobbySearch,
-		scenarioJoinRoom,
-		scenarioMessage,
-		scenarioKick,
-		scenarioSearchCurrent,
-	} {
+	for _, scenario := range scenarios {
 		err := scenario(ctx)
 		if err != nil {
 			return err

--- a/server/cmd/wsnet2-bot/cmd/scenario.go
+++ b/server/cmd/wsnet2-bot/cmd/scenario.go
@@ -37,6 +37,8 @@ var scenarios = map[string]func(context.Context) error{
 	"Message":       scenarioMessage,
 	"Kick":          scenarioKick,
 	"SearchCurrent": scenarioSearchCurrent,
+	"ClientProp":    scenarioClientProp,
+	"Rejoin":        scenarioRejoin,
 }
 
 func init() {
@@ -687,5 +689,164 @@ func scenarioSearchCurrent(ctx context.Context) error {
 		return fmt.Errorf("rooms %v, wants %v", ids, wants)
 	}
 
+	return nil
+}
+
+// scenarioClientProp : Playerのプロパティ変更テスト
+func scenarioClientProp(ctx context.Context) error {
+	logger.Infof("=== Scenario ClientProp ===")
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	room, master, err := createRoom(ctx, "cliprop_master", &pb.RoomOption{
+		Joinable:    true,
+		SearchGroup: ScenarioClientProp,
+	})
+	if err != nil {
+		return fmt.Errorf("cliprop: create: %w", err)
+	}
+	defer cleanupConn(ctx, master)
+
+	prop := binary.Dict{
+		"prop1": binary.MarshalInt(100),
+		"prop2": binary.MarshalStr8("abc"),
+	}
+
+	master.Send(binary.MsgTypeClientProp, binary.MarshalClientPropPayload(prop))
+
+	ev, ok := waitEvent(master, time.Second, binary.EvTypeClientProp)
+	if !ok {
+		return fmt.Errorf("cliprop: wait EvClientProp failed")
+	}
+	p, err := binary.UnmarshalEvClientPropPayload(ev.Payload())
+	if err != nil {
+		return fmt.Errorf("cliprop: unmarshal payload: %w", err)
+	}
+	logger.Infof("master prop: %v", p.Props)
+	if !reflect.DeepEqual(p.Props, prop) {
+		return fmt.Errorf("cliprop: prop %v, wants %v", p.Props, prop)
+	}
+
+	// "prop1"のみ変更
+	prop1 := binary.Dict{"prop1": binary.MarshalInt(200)}
+	master.Send(binary.MsgTypeClientProp, binary.MarshalClientPropPayload(prop1))
+
+	ev, ok = waitEvent(master, time.Second, binary.EvTypeClientProp)
+	if !ok {
+		return fmt.Errorf("cliprop: wait EvClientProp failed")
+	}
+	p, err = binary.UnmarshalEvClientPropPayload(ev.Payload())
+	if err != nil {
+		return fmt.Errorf("cliprop: unmarshal payload: %w", err)
+	}
+	logger.Infof("prop1: %v", p)
+	if reflect.DeepEqual(p, prop1) {
+		return fmt.Errorf("cliprop: prop1 %v, wants %v", p, prop)
+	}
+
+	// roomに保存されていることを確認
+	room2, player, err := joinRoom(ctx, "cliprop_player", room.Id, nil)
+	if err != nil {
+		return fmt.Errorf("cliprop: join: %w", err)
+	}
+	defer cleanupConn(ctx, player)
+
+	prop["prop1"] = prop1["prop1"]
+	mprop := room2.Players["cliprop_master"].Props
+	logger.Infof("master prop: %v", mprop)
+	if !reflect.DeepEqual(mprop, prop) {
+		return fmt.Errorf("cliprop: master prop: %v, wants %v", mprop, prop)
+	}
+
+	logger.Info("clientprop ok")
+	return nil
+}
+
+// scenarioRejoin : 再入室テスト
+func scenarioRejoin(ctx context.Context) error {
+	logger.Infof("=== Scenario Rejoin ===")
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	room, master, err := createRoom(ctx, "rejoin_master", &pb.RoomOption{
+		Joinable:    true,
+		SearchGroup: ScenarioRejoin,
+	})
+	if err != nil {
+		return fmt.Errorf("rejoin: create: %w", err)
+	}
+	defer cleanupConn(ctx, master)
+
+	_, ok := waitEvent(master, time.Second, binary.EvTypeJoined)
+	if !ok {
+		return fmt.Errorf("rejoin: wait EvJoined failed")
+	}
+
+	id := "rejoin_player"
+	_, player1, err := joinRoom(ctx, id, room.Id, nil)
+	if err != nil {
+		return fmt.Errorf("rejoin: join player1: %w", err)
+	}
+	discardEvents(player1)
+
+	ev, ok := waitEvent(master, time.Second, binary.EvTypeJoined)
+	if !ok {
+		return fmt.Errorf("rejoin: wait EvJoined failed")
+	}
+	c, err := binary.UnmarshalEvJoinedPayload(ev.Payload())
+	if err != nil {
+		return fmt.Errorf("rejoin: UnmarshalEvJoinedPayload: %w", err)
+	}
+	if c.Id != id {
+		return fmt.Errorf("rejoin: joined: %v, wants %v", c.Id, id)
+	}
+
+	// rejoin
+	_, player2, err := joinRoom(ctx, id, room.Id, nil)
+	if err != nil {
+		return fmt.Errorf("rejoin: join player2: %w", err)
+	}
+	defer cleanupConn(ctx, player2)
+	logger.Info("rejoin: player rejoined")
+
+	// master,player2にrejoin通知
+	ev, ok = waitEvent(master, time.Second, binary.EvTypeRejoined)
+	if !ok {
+		return fmt.Errorf("rejoin: wait EvRejoined failed")
+	}
+	c, err = binary.UnmarshalEvRejoinedPayload(ev.Payload())
+	if err != nil {
+		return fmt.Errorf("rejoin: UnmarshalEvRejoinedPayload: %w", err)
+	}
+	if c.Id != id {
+		return fmt.Errorf("rejoin: joined: %v, wants %v", c.Id, id)
+	}
+
+	ev, ok = waitEvent(player2, time.Second, binary.EvTypeRejoined)
+	if !ok {
+		return fmt.Errorf("rejoin: wait EvRejoined failed")
+	}
+	c, err = binary.UnmarshalEvRejoinedPayload(ev.Payload())
+	if err != nil {
+		return fmt.Errorf("rejoin: UnmarshalEvRejoinedPayload: %w", err)
+	}
+	if c.Id != id {
+		return fmt.Errorf("rejoin: joined: %v, wants %v", c.Id, id)
+	}
+
+	// player1は正常切断
+	ctx2, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	_, err = player1.Wait(ctx2)
+	if errors.Is(err, context.DeadlineExceeded) {
+		cleanupConn(ctx, player1)
+		return fmt.Errorf("rejoin: player1 did not left")
+	}
+	if err != nil {
+		return fmt.Errorf("rejoin: player1.Wait: %w", err)
+	}
+	logger.Info("rejoin: player1 closed")
+
+	logger.Info("rejoin ok")
 	return nil
 }


### PR DESCRIPTION
MsgClientPropと再入室のシナリオを追加しました。

go testでテストシナリオを流せるようにしました。
カバレッジをみてシナリオの網羅性を確認できます:
```sh
cd server/cmd/wsnet2-bot/cmd

docker run -d --rm \
  -v `pwd`/../../../sql/10-schema.sql:/docker-entrypoint-initdb.d/10-schema.sql \
  -v `pwd`/../../../sql/90-docker.sql:/docker-entrypoint-initdb.d/90-docker.sql \
  -e MYSQL_ROOT_PASSWORD=root \
  -e MYSQL_DATABASE=wsnet2 \
  -e MYSQL_USER=wsnet2 \
  -e MYSQL_PASSWORD=wsnet2pass \
  -p 3306:3306 mysql:8.0

go test . -cover -coverprofile=cover.out -tags scenariocoverage \
  -coverpkg=wsnet2/auth,wsnet2/binary,wsnet2/common,wsnet2/config,wsnet2/game,wsnet2/game/service,wsnet2/hub,wsnet2/hub/service,wsnet2/lobby,wsnet2/lobby/service,wsnet2/log,wsnet2/pb

go tool cover -html=cover.out -o cover.html
```