### PR TITLE
Goのシリアライザの32bit対応

### DIFF
--- a/.github/workflows/wsnet2-dashboard.yml
+++ b/.github/workflows/wsnet2-dashboard.yml
@@ -31,7 +31,7 @@ jobs:
 
       - run: go install golang.org/dl/go1.18.5@latest && go1.18.5 download
 
-      - run: go1.18.5 test wsnet2/binary
+      - run: GOARCH=386 go1.18.5 test wsnet2/binary
 
       - run: GOARCH=386 go1.18.5 build
 

--- a/server/binary/event.go
+++ b/server/binary/event.go
@@ -225,7 +225,7 @@ func UnmarshalEvPongPayload(payload []byte) (*EvPongPayload, error) {
 	if e != nil {
 		return nil, xerrors.Errorf("Invalid EvPong payload (watchers): %w", e)
 	}
-	pp.Watchers = uint32(d.(int))
+	pp.Watchers = uint32(d.(int64))
 	payload = payload[l:]
 
 	// lastmsg

--- a/server/binary/event.go
+++ b/server/binary/event.go
@@ -139,7 +139,7 @@ func UnmarshalEvent(data []byte) (Event, int, error) {
 	if len(data) < 4 {
 		return nil, 0, xerrors.Errorf("data length not enough: %v", len(data))
 	}
-	seq := get32(data)
+	seq := int(get32(data))
 	data = data[4:]
 
 	return &RegularEvent{et, data}, seq, nil
@@ -194,7 +194,7 @@ func UnmarshalEvPeerReadyPayload(payload []byte) (int, error) {
 // - dict: last msg timestamps of each player.
 func NewEvPong(pingtime uint64, watchers uint32, lastMsg Dict) *SystemEvent {
 	payload := MarshalULong(pingtime)
-	payload = append(payload, MarshalUInt(int(watchers))...)
+	payload = append(payload, MarshalUInt(int64(watchers))...)
 	payload = append(payload, MarshalDict(lastMsg)...)
 
 	return &SystemEvent{

--- a/server/binary/marshal.go
+++ b/server/binary/marshal.go
@@ -201,7 +201,7 @@ func unmarshalShort(src []byte) (int, int, error) {
 }
 
 // MarshalUInt marshals unsigned 32bit integer
-func MarshalUInt(val int) []byte {
+func MarshalUInt(val int64) []byte {
 	v := clamp(int64(val), 0, math.MaxUint32)
 	buf := make([]byte, 1+UIntDataSize)
 	buf[0] = byte(TypeUInt)
@@ -209,7 +209,7 @@ func MarshalUInt(val int) []byte {
 	return buf
 }
 
-func unmarshalUInt(src []byte) (int, int, error) {
+func unmarshalUInt(src []byte) (int64, int, error) {
 	if len(src) < 1+UIntDataSize {
 		return 0, 0, xerrors.Errorf("Unmarshal UInt error: not enough data (%v)", len(src))
 	}
@@ -217,7 +217,7 @@ func unmarshalUInt(src []byte) (int, int, error) {
 }
 
 // MarshalInt marshals signed 32bit integer comparably
-func MarshalInt(val int) []byte {
+func MarshalInt(val int64) []byte {
 	v := clamp(int64(val), math.MinInt32, math.MaxInt32)
 	buf := make([]byte, 1+IntDataSize)
 	buf[0] = byte(TypeInt)
@@ -225,7 +225,7 @@ func MarshalInt(val int) []byte {
 	return buf
 }
 
-func unmarshalInt(src []byte) (int, int, error) {
+func unmarshalInt(src []byte) (int64, int, error) {
 	if len(src) < 1+IntDataSize {
 		return 0, 0, xerrors.Errorf("Unmarshal Int error: not enough data (%v)", len(src))
 	}
@@ -773,7 +773,7 @@ func unmarshalUShorts(src []byte) ([]int, int, error) {
 //   - TypeInts
 //   - 16bit count
 //   - repeat: 32bit BE integer...
-func MarshalInts(vals []int) []byte {
+func MarshalInts(vals []int64) []byte {
 	if vals == nil {
 		return MarshalNull()
 	}
@@ -787,14 +787,14 @@ func MarshalInts(vals []int) []byte {
 	put16(buf[1:], int64(count))
 
 	for i := 0; i < count; i++ {
-		v := clamp(int64(vals[i]), math.MinInt32, math.MaxInt32) - math.MinInt32
+		v := clamp(vals[i], math.MinInt32, math.MaxInt32) - math.MinInt32
 		put32(buf[3+i*IntDataSize:], v)
 	}
 
 	return buf
 }
 
-func unmarshalInts(src []byte) ([]int, int, error) {
+func unmarshalInts(src []byte) ([]int64, int, error) {
 	if len(src) < 3 {
 		return nil, 0, xerrors.Errorf("Unmarshal Intts error: not enough data (%v)", len(src))
 	}
@@ -803,7 +803,7 @@ func unmarshalInts(src []byte) ([]int, int, error) {
 	if len(src) < l {
 		return nil, 0, xerrors.Errorf("Unmarshal Ints error: not enough data (%v)", len(src))
 	}
-	vals := make([]int, count)
+	vals := make([]int64, count)
 	for i := 0; i < count; i++ {
 		vals[i] = get32(src[3+i*IntDataSize:]) + math.MinInt32
 	}
@@ -815,7 +815,7 @@ func unmarshalInts(src []byte) ([]int, int, error) {
 //   - TypeUInts
 //   - 16bit count
 //   - repeat: 32bit BE integer...
-func MarshalUInts(vals []int) []byte {
+func MarshalUInts(vals []int64) []byte {
 	if vals == nil {
 		return MarshalNull()
 	}
@@ -829,14 +829,14 @@ func MarshalUInts(vals []int) []byte {
 	put16(buf[1:], int64(count))
 
 	for i := 0; i < count; i++ {
-		v := clamp(int64(vals[i]), 0, math.MaxUint32)
+		v := clamp(vals[i], 0, math.MaxUint32)
 		put32(buf[3+i*UIntDataSize:], v)
 	}
 
 	return buf
 }
 
-func unmarshalUInts(src []byte) ([]int, int, error) {
+func unmarshalUInts(src []byte) ([]int64, int, error) {
 	if len(src) < 3 {
 		return nil, 0, xerrors.Errorf("Unmarshal UInts error: not enough data (%v)", len(src))
 	}
@@ -845,7 +845,7 @@ func unmarshalUInts(src []byte) ([]int, int, error) {
 	if len(src) < l {
 		return nil, 0, xerrors.Errorf("Unmarshal UInts error: not enough data (%v)", len(src))
 	}
-	vals := make([]int, count)
+	vals := make([]int64, count)
 	for i := 0; i < count; i++ {
 		vals[i] = get32(src[3+i*UIntDataSize:])
 	}
@@ -1211,11 +1211,11 @@ func put32(dst []byte, val int64) {
 	dst[2] = byte((val & 0xff00) >> 8)
 	dst[3] = byte(val & 0xff)
 }
-func get32(src []byte) int {
-	i := int(src[0]) << 24
-	i += int(src[1]) << 16
-	i += int(src[2]) << 8
-	i += int(src[3])
+func get32(src []byte) int64 {
+	i := int64(src[0]) << 24
+	i += int64(src[1]) << 16
+	i += int64(src[2]) << 8
+	i += int64(src[3])
 	return i
 }
 

--- a/server/binary/marshal.go
+++ b/server/binary/marshal.go
@@ -1,6 +1,7 @@
 package binary
 
 import (
+	"encoding/binary"
 	"math"
 	"unicode/utf16"
 
@@ -1182,14 +1183,11 @@ func get8(src []byte) int {
 }
 
 func put16(dst []byte, val int64) {
-	dst[1] = byte(val & 0xff)
-	dst[0] = byte((val & 0xff00) >> 8)
+	binary.BigEndian.PutUint16(dst, uint16(val))
 }
 
 func get16(src []byte) int {
-	v := int(src[1])
-	v |= int(src[0]) << 8
-	return v
+	return int(binary.BigEndian.Uint16(src))
 }
 
 func put24(dst []byte, val int64) {
@@ -1206,39 +1204,17 @@ func get24(src []byte) int {
 }
 
 func put32(dst []byte, val int64) {
-	dst[3] = byte(val & 0xff)
-	dst[2] = byte((val & 0xff00) >> 8)
-	dst[1] = byte((val & 0xff0000) >> 16)
-	dst[0] = byte((val & 0xff000000) >> 24)
+	binary.BigEndian.PutUint32(dst, uint32(val))
 }
 
 func get32(src []byte) int64 {
-	i := int64(src[3])
-	i |= int64(src[2]) << 8
-	i |= int64(src[1]) << 16
-	i |= int64(src[0]) << 24
-	return i
+	return int64(binary.BigEndian.Uint32(src))
 }
 
 func put64(dst []byte, val uint64) {
-	dst[7] = byte(val & 0xff)
-	dst[6] = byte((val & 0xff00) >> 8)
-	dst[5] = byte((val & 0xff0000) >> 16)
-	dst[4] = byte((val & 0xff000000) >> 24)
-	dst[3] = byte((val & 0xff00000000) >> 32)
-	dst[2] = byte((val & 0xff0000000000) >> 40)
-	dst[1] = byte((val & 0xff000000000000) >> 48)
-	dst[0] = byte((val & 0xff00000000000000) >> 56)
+	binary.BigEndian.PutUint64(dst, val)
 }
 
 func get64(src []byte) uint64 {
-	i := uint64(src[7])
-	i |= uint64(src[6]) << 8
-	i |= uint64(src[5]) << 16
-	i |= uint64(src[4]) << 24
-	i |= uint64(src[3]) << 32
-	i |= uint64(src[2]) << 40
-	i |= uint64(src[1]) << 48
-	i |= uint64(src[0]) << 56
-	return i
+	return binary.BigEndian.Uint64(src)
 }

--- a/server/binary/marshal.go
+++ b/server/binary/marshal.go
@@ -1182,62 +1182,63 @@ func get8(src []byte) int {
 }
 
 func put16(dst []byte, val int64) {
-	dst[0] = byte((val & 0xff00) >> 8)
 	dst[1] = byte(val & 0xff)
+	dst[0] = byte((val & 0xff00) >> 8)
 }
 
 func get16(src []byte) int {
-	v := int(src[0]) << 8
-	v += int(src[1])
+	v := int(src[1])
+	v |= int(src[0]) << 8
 	return v
 }
 
 func put24(dst []byte, val int64) {
-	dst[0] = byte((val & 0xff0000) >> 16)
-	dst[1] = byte((val & 0xff00) >> 8)
 	dst[2] = byte(val & 0xff)
+	dst[1] = byte((val & 0xff00) >> 8)
+	dst[0] = byte((val & 0xff0000) >> 16)
 }
 
 func get24(src []byte) int {
-	i := int(src[0]) << 16
-	i += int(src[1]) << 8
-	i += int(src[2])
+	i := int(src[2])
+	i |= int(src[1]) << 8
+	i |= int(src[0]) << 16
 	return i
 }
 
 func put32(dst []byte, val int64) {
-	dst[0] = byte((val & 0xff000000) >> 24)
-	dst[1] = byte((val & 0xff0000) >> 16)
-	dst[2] = byte((val & 0xff00) >> 8)
 	dst[3] = byte(val & 0xff)
+	dst[2] = byte((val & 0xff00) >> 8)
+	dst[1] = byte((val & 0xff0000) >> 16)
+	dst[0] = byte((val & 0xff000000) >> 24)
 }
+
 func get32(src []byte) int64 {
-	i := int64(src[0]) << 24
-	i += int64(src[1]) << 16
-	i += int64(src[2]) << 8
-	i += int64(src[3])
+	i := int64(src[3])
+	i |= int64(src[2]) << 8
+	i |= int64(src[1]) << 16
+	i |= int64(src[0]) << 24
 	return i
 }
 
 func put64(dst []byte, val uint64) {
-	dst[0] = byte((val & 0xff00000000000000) >> 56)
-	dst[1] = byte((val & 0xff000000000000) >> 48)
-	dst[2] = byte((val & 0xff0000000000) >> 40)
-	dst[3] = byte((val & 0xff00000000) >> 32)
-	dst[4] = byte((val & 0xff000000) >> 24)
-	dst[5] = byte((val & 0xff0000) >> 16)
-	dst[6] = byte((val & 0xff00) >> 8)
 	dst[7] = byte(val & 0xff)
+	dst[6] = byte((val & 0xff00) >> 8)
+	dst[5] = byte((val & 0xff0000) >> 16)
+	dst[4] = byte((val & 0xff000000) >> 24)
+	dst[3] = byte((val & 0xff00000000) >> 32)
+	dst[2] = byte((val & 0xff0000000000) >> 40)
+	dst[1] = byte((val & 0xff000000000000) >> 48)
+	dst[0] = byte((val & 0xff00000000000000) >> 56)
 }
 
 func get64(src []byte) uint64 {
-	i := uint64(src[0]) << 56
-	i += uint64(src[1]) << 48
-	i += uint64(src[2]) << 40
-	i += uint64(src[3]) << 32
-	i += uint64(src[4]) << 24
-	i += uint64(src[5]) << 16
-	i += uint64(src[6]) << 8
-	i += uint64(src[7])
+	i := uint64(src[7])
+	i |= uint64(src[6]) << 8
+	i |= uint64(src[5]) << 16
+	i |= uint64(src[4]) << 24
+	i |= uint64(src[3]) << 32
+	i |= uint64(src[2]) << 40
+	i |= uint64(src[1]) << 48
+	i |= uint64(src[0]) << 56
 	return i
 }

--- a/server/binary/msg.go
+++ b/server/binary/msg.go
@@ -194,7 +194,7 @@ func UnmarshalPingPayload(payload []byte) (uint64, error) {
 
 // NewMsgNodeCount constructs MsgNodeCount
 func NewMsgNodeCount(count uint32) Msg {
-	payload := MarshalUInt(int(count))
+	payload := MarshalUInt(int64(count))
 	return &nonregularMsg{
 		mtype:   MsgTypeNodeCount,
 		payload: payload,
@@ -270,7 +270,7 @@ func MarshalRoomPropPayload(visible, joinable, watchable bool, searchGroup, maxP
 	}
 	p := make([]byte, 0, 15)
 	p = append(p, MarshalByte(flg)...)
-	p = append(p, MarshalUInt(int(searchGroup))...)
+	p = append(p, MarshalUInt(int64(searchGroup))...)
 	p = append(p, MarshalUShort(int(maxPlayer))...)
 	p = append(p, MarshalUShort(int(clientDeadline))...)
 	p = append(p, MarshalDict(publicProps)...)
@@ -300,7 +300,7 @@ func UnmarshalRoomPropPayload(payload []byte) (*MsgRoomPropPayload, error) {
 	if e != nil {
 		return nil, xerrors.Errorf("Invalid MsgRoomProp payload (search group): %w", e)
 	}
-	rpp.SearchGroup = uint32(d.(int))
+	rpp.SearchGroup = uint32(d.(int64))
 	payload = payload[l:]
 
 	// max players

--- a/server/binary/msg.go
+++ b/server/binary/msg.go
@@ -207,7 +207,7 @@ func UnmarshalNodeCountPayload(payload []byte) (uint32, error) {
 	if e != nil {
 		return 0, xerrors.Errorf("Invalid MsgNodeCount payload (node count): %w", e)
 	}
-	return uint32(d.(int)), nil
+	return uint32(d.(int64)), nil
 }
 
 // MarshalLeavePayload marshals MsgLeave payload

--- a/server/binary/unmarshal_recursive_test.go
+++ b/server/binary/unmarshal_recursive_test.go
@@ -16,11 +16,11 @@ func TestUnmarshalRecursive(t *testing.T) {
 	}{
 		{
 			[]byte{byte(binary.TypeInt), 0x80, 0x00, 0x00, 0x01},
-			int(1),
+			int64(1),
 		},
 		{
 			[]byte{byte(binary.TypeUInt), 0x01, 0x02, 0x03, 0x04, byte(binary.TypeStr8), 0x03, 'a', 'b', 'c'},
-			[]interface{}{int(0x1020304), "abc"},
+			[]interface{}{int64(0x1020304), "abc"},
 		},
 		{
 			[]byte{

--- a/server/cmd/wsnet2-bot/cmd/soak.go
+++ b/server/cmd/wsnet2-bot/cmd/soak.go
@@ -265,7 +265,7 @@ func runMaster(ctx context.Context, conn *client.Connection, lifetime time.Durat
 		for {
 			conn.Send(binary.MsgTypeRoomProp, binary.MarshalRoomPropPayload(
 				true, true, true, group, 10, 0,
-				binary.Dict{"score": binary.MarshalInt(rand.Intn(1024))}, binary.Dict{}))
+				binary.Dict{"score": binary.MarshalInt(rand.Int63n(1024))}, binary.Dict{}))
 
 			select {
 			case <-sendctx.Done():

--- a/server/cmd/wsnet2-tool/cmd/rooms.go
+++ b/server/cmd/wsnet2-tool/cmd/rooms.go
@@ -143,9 +143,13 @@ func parsePropsSimple(data []byte) (string, error) {
 			if err != nil {
 				return string(out), err
 			}
-		case binary.TypeSBytes, binary.TypeBytes, binary.TypeShorts, binary.TypeUShorts,
-			binary.TypeInts, binary.TypeUInts, binary.TypeLongs:
+		case binary.TypeSBytes, binary.TypeBytes, binary.TypeShorts, binary.TypeUShorts:
 			out, err = appendPrimitiveArraySimple[int](out, d)
+			if err != nil {
+				return string(out), err
+			}
+		case binary.TypeInts, binary.TypeUInts, binary.TypeLongs:
+			out, err = appendPrimitiveArraySimple[int64](out, d)
 			if err != nil {
 				return string(out), err
 			}

--- a/server/cmd/wsnet2-tool/cmd/rooms_test.go
+++ b/server/cmd/wsnet2-tool/cmd/rooms_test.go
@@ -69,8 +69,8 @@ func TestAppendPrimitiveArraySimple(t *testing.T) {
 			exp:  `"Bools[5]",`,
 		},
 		"ints4": {
-			data: binary.MarshalInts([]int{1, 2, 3, 4}),
-			fnc:  appendPrimitiveArraySimple[int],
+			data: binary.MarshalInts([]int64{1, 2, 3, 4}),
+			fnc:  appendPrimitiveArraySimple[int64],
 			exp:  "[1,2,3,4],",
 		},
 		"bytes5": {

--- a/server/lobby/prop_query_test.go
+++ b/server/lobby/prop_query_test.go
@@ -516,7 +516,7 @@ func TestPropQueryMatchContains(t *testing.T) {
 			binary.MarshalStr16("あいうえお"),
 			binary.MarshalDouble(10),
 		}),
-		"bbb": binary.MarshalInts([]int{1, 3, 5, 7, 9}),
+		"bbb": binary.MarshalInts([]int64{1, 3, 5, 7, 9}),
 		"ccc": binary.MarshalFloats([]float32{-10, -0.5, 0, 1.1}),
 	}
 	tests := []struct {


### PR DESCRIPTION
Goのシリアライザは64bit環境前提で作っていました（符号有/無の32bit intをどちらも`int`で扱っていた）
ところが、dashboardで使っているGopherjsが32bit環境をエミュレートしているため、桁溢れするときに正しく扱えていませんでした。

32bit環境でも変わらないよう、Int/UIntはint64で扱うようにして、テストも32bitで通るようにしました。

Unmarshalの結果が`interface{}`で、一部型アサーションしてる部分があり、
この書きかえがコンパイル時チェックできないので、漏れがないか注意して見てほしいです。