### PR TITLE
Fix game.RandomHex() to return a string of correct length

### DIFF
--- a/server/common/const.go
+++ b/server/common/const.go
@@ -4,4 +4,7 @@ const (
 	HostStatusStarting = 0
 	HostStatusRunning  = 1
 	HostStatusClosing  = 2
+
+	RoomIdLen     = 32
+	RoomIdPattern = "^[0-9a-f]+$"
 )

--- a/server/common/const.go
+++ b/server/common/const.go
@@ -6,5 +6,5 @@ const (
 	HostStatusClosing  = 2
 
 	RoomIdLen     = 32
-	RoomIdPattern = "^[0-9a-f]+$"
+	RoomIdPattern = "^[0-9a-f]{32}$"
 )

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -187,7 +187,7 @@ func Load(conffile string) (*Config, error) {
 			ClientConf: ClientConf{
 				EventBufSize:   128,
 				WaitAfterClose: Duration(30 * time.Second),
-				AuthKeyLen:     32,
+				AuthKeyLen:     64,
 			},
 
 			LogConf: LogConf{
@@ -217,7 +217,7 @@ func Load(conffile string) (*Config, error) {
 			ClientConf: ClientConf{
 				EventBufSize:   128,
 				WaitAfterClose: Duration(30 * time.Second),
-				AuthKeyLen:     32,
+				AuthKeyLen:     64,
 			},
 
 			LogConf: LogConf{

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -48,7 +48,7 @@ func TestLoad(t *testing.T) {
 		ClientConf: ClientConf{
 			EventBufSize:   512,
 			WaitAfterClose: Duration(time.Second * 60),
-			AuthKeyLen:     32,
+			AuthKeyLen:     64,
 		},
 
 		LogConf: LogConf{

--- a/server/game/repository.go
+++ b/server/game/repository.go
@@ -19,16 +19,10 @@ import (
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc/codes"
 
+	"wsnet2/common"
 	"wsnet2/config"
 	"wsnet2/log"
 	"wsnet2/pb"
-)
-
-const (
-	// RoomID文字列長
-	lenId = 32
-
-	idPattern = "^[0-9a-f]+$"
 )
 
 var (
@@ -46,7 +40,7 @@ func init() {
 	seed, _ := crand.Int(crand.Reader, big.NewInt(math.MaxInt64))
 	randsrc = rand.New(rand.NewSource(seed.Int64()))
 
-	rerid = regexp.MustCompile(idPattern)
+	rerid = regexp.MustCompile(common.RoomIdPattern)
 }
 
 func dbCols(t reflect.Type) []string {
@@ -309,7 +303,7 @@ func (repo *Repository) newRoomInfo(ctx context.Context, tx *sqlx.Tx, op *pb.Roo
 		default:
 		}
 
-		ri.Id = RandomHex(lenId)
+		ri.Id = RandomHex(common.RoomIdLen)
 		if op.WithNumber {
 			ri.Number.Number = randsrc.Int31n(maxNumber) + 1 // [1..maxNumber]
 		}

--- a/server/game/repository.go
+++ b/server/game/repository.go
@@ -84,9 +84,9 @@ func initQueries() {
 }
 
 func RandomHex(n int) string {
-	b := make([]byte, n)
+	b := make([]byte, (n+1)/2)
 	_, _ = randsrc.Read(b) // (*rand.Rand).Read always success.
-	return hex.EncodeToString(b)
+	return hex.EncodeToString(b)[:n]
 }
 
 func IsValidRoomId(id string) bool {

--- a/server/game/repository.go
+++ b/server/game/repository.go
@@ -84,7 +84,7 @@ func RandomHex(n int) string {
 }
 
 func IsValidRoomId(id string) bool {
-	return rerid.Match([]byte(id))
+	return rerid.MatchString(id)
 }
 
 type Repository struct {

--- a/server/game/repository.go
+++ b/server/game/repository.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	// RoomID文字列長
-	lenId = 16
+	lenId = 32
 
 	idPattern = "^[0-9a-f]+$"
 )

--- a/server/game/repository_test.go
+++ b/server/game/repository_test.go
@@ -130,3 +130,16 @@ func TestNewRoomInfo(t *testing.T) {
 		t.Errorf("there were unfulfilled expectations: %s", err)
 	}
 }
+
+func TestRandomHexRoomId(t *testing.T) {
+	rid := RandomHex(lenId)
+
+	if len(rid) != lenId {
+		t.Errorf("room id len = %v wants %v (%q)", len(rid), lenId, rid)
+	}
+
+	ok, err := regexp.MatchString(idPattern, rid)
+	if err != nil || !ok {
+		t.Errorf("room id pattern missmatch: %v", rid)
+	}
+}

--- a/server/game/repository_test.go
+++ b/server/game/repository_test.go
@@ -40,9 +40,11 @@ func TestQueries(t *testing.T) {
 
 func TestIsValidRoomId(t *testing.T) {
 	tests := map[string]bool{
-		"123456789abcdef": true,
-		"123456789ABCDEF": false,
-		"":                false,
+		"0123456789abcdef0123456789abcdef":  true,
+		"0123456789ABCDEF0123456789ABCDEF":  false,
+		"0123456789abcdef0123456789abcde":   false,
+		"0123456789abcdef0123456789abcdef0": false,
+		"":                                  false,
 	}
 
 	for id, valid := range tests {

--- a/server/game/repository_test.go
+++ b/server/game/repository_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"golang.org/x/xerrors"
 
+	"wsnet2/common"
 	"wsnet2/config"
 	"wsnet2/pb"
 )
@@ -60,6 +61,7 @@ func newDbMock(t *testing.T) (*sqlx.DB, sqlmock.Sqlmock) {
 }
 
 func TestNewRoomInfo(t *testing.T) {
+	const lenId = common.RoomIdLen
 	ctx := context.Background()
 	db, mock := newDbMock(t)
 	retryCount := 3
@@ -132,13 +134,14 @@ func TestNewRoomInfo(t *testing.T) {
 }
 
 func TestRandomHexRoomId(t *testing.T) {
+	const lenId = common.RoomIdLen
 	rid := RandomHex(lenId)
 
 	if len(rid) != lenId {
 		t.Errorf("room id len = %v wants %v (%q)", len(rid), lenId, rid)
 	}
 
-	ok, err := regexp.MatchString(idPattern, rid)
+	ok, err := regexp.MatchString(common.RoomIdPattern, rid)
 	if err != nil || !ok {
 		t.Errorf("room id pattern missmatch: %v", rid)
 	}

--- a/server/lobby/service/api.go
+++ b/server/lobby/service/api.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"wsnet2/auth"
+	"wsnet2/common"
 	"wsnet2/lobby"
 	"wsnet2/log"
 	"wsnet2/pb"
@@ -248,7 +249,7 @@ func (sv *LobbyService) handleCreateRoom(w http.ResponseWriter, r *http.Request)
 }
 
 var (
-	idRegexp = regexp.MustCompile("^[0-9a-f]+$")
+	idRegexp = regexp.MustCompile(common.RoomIdPattern)
 )
 
 type JoinVars struct {


### PR DESCRIPTION
`game.RandomHex(n int)` の返す文字列が2nになってしまっていたのを修正しました

RandomHexで生成していたのは次の2箇所です
- RoomID
  - これまで通り32文字になるようconstを修正
- クライアントのAuthKey
  - configでの指定値の倍の長さになっていたのが指定値通りに
  - 無指定の場合これまでと同じ長さになるよう初期値を修正

ついでにRoomIDの長さや正規表現のconstをcommonパッケージに移して共通化しました