### PR TITLE
Use math/rand/v2

### DIFF
--- a/server/cmd/wsnet2-bot/cmd/load.go
+++ b/server/cmd/wsnet2-bot/cmd/load.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"os/signal"
 	"sync"
@@ -126,7 +126,7 @@ func runLoadWorker(ctx context.Context, p, w int, minLifeTime, maxLifeTime time.
 	lifetimeRange := int(maxLifeTime - minLifeTime)
 	n := 0
 	for {
-		time.Sleep(time.Millisecond * time.Duration(rand.Intn(100)))
+		time.Sleep(time.Millisecond * time.Duration(rand.IntN(100)))
 
 		select {
 		case <-ctx.Done():
@@ -136,7 +136,7 @@ func runLoadWorker(ctx context.Context, p, w int, minLifeTime, maxLifeTime time.
 
 		lifetime := minLifeTime
 		if lifetimeRange > 0 {
-			lifetime += time.Duration(rand.Intn(lifetimeRange))
+			lifetime += time.Duration(rand.IntN(lifetimeRange))
 		}
 		widsuffix := fmt.Sprintf("%v-%v", wid, n)
 		logprefix := fmt.Sprintf("room[%v]", widsuffix)

--- a/server/cmd/wsnet2-bot/cmd/soak.go
+++ b/server/cmd/wsnet2-bot/cmd/soak.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"os/signal"
 	"sync"
@@ -101,7 +101,7 @@ func runSoak(ctx context.Context, roomCount int, minLifeTime, maxLifeTime time.D
 		go func(n int) {
 			lifetime := minLifeTime
 			if lifetimeRange != 0 {
-				lifetime += time.Duration(rand.Intn(lifetimeRange))
+				lifetime += time.Duration(rand.IntN(lifetimeRange))
 			}
 			err := runSoakRoom(ctx, n, lifetime)
 			if err != nil {
@@ -248,7 +248,7 @@ func runMaster(ctx context.Context, conn *client.Connection, lifetime time.Durat
 		defer t.Stop()
 
 		for {
-			conn.Send(binary.MsgTypeBroadcast, msgBody[:rand.Intn(30)+30])
+			conn.Send(binary.MsgTypeBroadcast, msgBody[:rand.IntN(30)+30])
 
 			select {
 			case <-sendctx.Done():
@@ -265,7 +265,7 @@ func runMaster(ctx context.Context, conn *client.Connection, lifetime time.Durat
 		for {
 			conn.Send(binary.MsgTypeRoomProp, binary.MarshalRoomPropPayload(
 				true, true, true, group, 10, 0,
-				binary.Dict{"score": binary.MarshalInt(rand.Int63n(1024))}, binary.Dict{}))
+				binary.Dict{"score": binary.MarshalInt(rand.Int64N(1024))}, binary.Dict{}))
 
 			select {
 			case <-sendctx.Done():
@@ -344,7 +344,7 @@ func runPlayer(ctx context.Context, conn *client.Connection, masterId, logprefix
 		defer t.Stop()
 
 		for {
-			conn.Send(binary.MsgTypeToMaster, msgBody[:rand.Intn(30)+30])
+			conn.Send(binary.MsgTypeToMaster, msgBody[:rand.IntN(30)+30])
 
 			select {
 			case <-sendctx.Done():
@@ -394,7 +394,7 @@ func runWatcher(ctx context.Context, conn *client.Connection, logprefix string) 
 		defer t.Stop()
 
 		for {
-			conn.Send(binary.MsgTypeToMaster, msgBody[:rand.Intn(30)+30])
+			conn.Send(binary.MsgTypeToMaster, msgBody[:rand.IntN(30)+30])
 
 			select {
 			case <-sendctx.Done():

--- a/server/cmd/wsnet2-bot/cmd/watch.go
+++ b/server/cmd/wsnet2-bot/cmd/watch.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"os/signal"
 	"sync"
@@ -70,7 +70,7 @@ func runLoadWatcher(ctx context.Context, watcherCount int) error {
 	for i := 0; i < watcherCount; i++ {
 		go func(i int) {
 			defer wg.Done()
-			time.Sleep(time.Duration(rand.Intn(900)+100) * time.Millisecond)
+			time.Sleep(time.Duration(rand.IntN(900)+100) * time.Millisecond)
 
 			watcherId := fmt.Sprintf("watcher-%v-%v", pid, i)
 			logprefix := fmt.Sprintf("watcher[%v]", i)

--- a/server/game/repository.go
+++ b/server/game/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	crand "crypto/rand"
 	"database/sql"
+	"encoding/binary"
 	"fmt"
 	"math/rand/v2"
 	"reflect"
@@ -36,9 +37,11 @@ var (
 func init() {
 	initQueries()
 
-	var seed [32]byte
+	var seed [16]byte
 	_, _ = crand.Read(seed[:])
-	randsrc = rand.New(rand.NewChaCha8(seed))
+	s1 := binary.NativeEndian.Uint64(seed[:8])
+	s2 := binary.NativeEndian.Uint64(seed[8:])
+	randsrc = rand.New(rand.NewPCG(s1, s2))
 
 	rerid = regexp.MustCompile(common.RoomIdPattern)
 }

--- a/server/lobby/game_cache.go
+++ b/server/lobby/game_cache.go
@@ -1,7 +1,7 @@
 package lobby
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -108,7 +108,7 @@ func (c *gameCache) Rand() (*gameServer, error) {
 	if len(c.order) == 0 {
 		return nil, xerrors.New("no available game server")
 	}
-	id := c.order[rand.Intn(len(c.order))]
+	id := c.order[rand.IntN(len(c.order))]
 	return c.servers[id], nil
 }
 

--- a/server/lobby/hub_cache.go
+++ b/server/lobby/hub_cache.go
@@ -1,7 +1,7 @@
 package lobby
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -89,6 +89,6 @@ func (c *hubCache) Rand() (*hubServer, error) {
 	if len(c.order) == 0 {
 		return nil, xerrors.New("no available hub server")
 	}
-	id := c.order[rand.Intn(len(c.order))]
+	id := c.order[rand.IntN(len(c.order))]
 	return c.servers[id], nil
 }

--- a/server/lobby/room.go
+++ b/server/lobby/room.go
@@ -3,7 +3,7 @@ package lobby
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"sort"
 	"sync"
 	"time"
@@ -392,7 +392,7 @@ func (rs *RoomService) watch(ctx context.Context, room *pb.RoomInfo, clientInfo 
 
 	var hub *hubServer
 	if len(hubIDs) > 0 {
-		n := rand.Intn(len(hubIDs))
+		n := rand.IntN(len(hubIDs))
 		hub, err = rs.hubCache.Get(hubIDs[n])
 	} else {
 		hub, err = rs.hubCache.Rand()


### PR DESCRIPTION
go 1.22.0 で math/rand の新しいバージョンが入ったので載せ替えました。

- import を v2に変更
- IntnをIntNにリネーム
- game.Repositoryが使うrandsrcを修正
  - ChaCha8よりPCGのほうが高速
  - RandomHexを修正