### PR TITLE
dotnet更新

### DIFF
--- a/wsnet2-dotnet/WSNet2.Client/WSNet2.Client.csproj
+++ b/wsnet2-dotnet/WSNet2.Client/WSNet2.Client.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MessagePack" Version="2.1.115" />
+    <PackageReference Include="MessagePack" Version="3.1.0" />
     <Compile Include="../../wsnet2-unity/Assets/WSNet2/Scripts/Core/**/*.cs" />
   </ItemGroup>
 

--- a/wsnet2-dotnet/WSNet2.Core.Test/QueryTests.cs
+++ b/wsnet2-dotnet/WSNet2.Core.Test/QueryTests.cs
@@ -104,8 +104,8 @@ namespace WSNet2.Core.Test
             query.Or();
             var expect = new object[] { new object[] { } };
             Assert.AreEqual(
-                MessagePackSerializer.Serialize(expect),
-                MessagePackSerializer.Serialize(query.condsList));
+                MessagePackSerializer.SerializeToJson(expect),
+                MessagePackSerializer.SerializeToJson(query.condsList));
 
             // ()*(A+B) = (A+B)
             query.Or(
@@ -121,14 +121,14 @@ namespace WSNet2.Core.Test
                 },
             };
             Assert.AreEqual(
-                MessagePackSerializer.Serialize(expect),
-                MessagePackSerializer.Serialize(query.condsList));
+                MessagePackSerializer.SerializeToJson(expect),
+                MessagePackSerializer.SerializeToJson(query.condsList));
 
             // (A+B)*() = (A+B)
             query.Or(new Query());
             Assert.AreEqual(
-                MessagePackSerializer.Serialize(expect),
-                MessagePackSerializer.Serialize(query.condsList));
+                MessagePackSerializer.SerializeToJson(expect),
+                MessagePackSerializer.SerializeToJson(query.condsList));
 
             // (A+B)*((C+D)+(E)) = (AC+AD+AE+BC+BD+BE)
             var q2 = new Query().Or(
@@ -164,8 +164,8 @@ namespace WSNet2.Core.Test
             };
             query.Or(new Query());
             Assert.AreEqual(
-                MessagePackSerializer.Serialize(expect),
-                MessagePackSerializer.Serialize(query.condsList));
+                MessagePackSerializer.SerializeToJson(expect),
+                MessagePackSerializer.SerializeToJson(query.condsList));
         }
 
         [Test]
@@ -196,8 +196,8 @@ namespace WSNet2.Core.Test
             };
 
             Assert.AreEqual(
-                MessagePackSerializer.Serialize(expect),
-                MessagePackSerializer.Serialize(query.condsList));
+                MessagePackSerializer.SerializeToJson(expect),
+                MessagePackSerializer.SerializeToJson(query.condsList));
         }
 
         [Test]
@@ -218,8 +218,8 @@ namespace WSNet2.Core.Test
             };
 
             Assert.AreEqual(
-                MessagePackSerializer.Serialize(expect),
-                MessagePackSerializer.Serialize(query.condsList));
+                MessagePackSerializer.SerializeToJson(expect),
+                MessagePackSerializer.SerializeToJson(query.condsList));
         }
 
         [Test]
@@ -239,8 +239,8 @@ namespace WSNet2.Core.Test
             };
 
             Assert.AreEqual(
-                MessagePackSerializer.Serialize(expect),
-                MessagePackSerializer.Serialize(query.condsList));
+                MessagePackSerializer.SerializeToJson(expect),
+                MessagePackSerializer.SerializeToJson(query.condsList));
         }
 
         [Test]
@@ -278,8 +278,8 @@ namespace WSNet2.Core.Test
             };
 
             Assert.AreEqual(
-                MessagePackSerializer.Serialize(expect),
-                MessagePackSerializer.Serialize(query.condsList));
+                MessagePackSerializer.SerializeToJson(expect),
+                MessagePackSerializer.SerializeToJson(query.condsList));
 
             query.Equal("k3", 100);
             query.Or(
@@ -345,8 +345,8 @@ namespace WSNet2.Core.Test
             };
 
             Assert.AreEqual(
-                MessagePackSerializer.Serialize(expect),
-                MessagePackSerializer.Serialize(query.condsList));
+                MessagePackSerializer.SerializeToJson(expect),
+                MessagePackSerializer.SerializeToJson(query.condsList));
         }
 
         [Test]

--- a/wsnet2-dotnet/WSNet2.Core.Test/WSNet2.Core.Test.csproj
+++ b/wsnet2-dotnet/WSNet2.Core.Test/WSNet2.Core.Test.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MessagePack" Version="2.1.152" />
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="MessagePack" Version="3.1.0" />
+    <PackageReference Include="nunit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <Compile Include="../../wsnet2-unity/Assets/WSNet2/Scripts/Core/**/*.cs" />
   </ItemGroup>
 

--- a/wsnet2-dotnet/WSNet2.Sample/WSNet2.Sample.csproj
+++ b/wsnet2-dotnet/WSNet2.Sample/WSNet2.Sample.csproj
@@ -2,15 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MessagePack" Version="2.1.115" />
+    <PackageReference Include="MessagePack" Version="3.1.0" />
     <Compile Include="../../wsnet2-unity/Assets/WSNet2/Scripts/Core/**/*.cs" />
     <Compile Include="../../wsnet2-unity/Assets/Sample/Logic/**/*.cs" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="ZLogger" Version="1.6.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageReference Include="ZLogger" Version="1.7.1" />
   </ItemGroup>
 
 </Project>

--- a/wsnet2-unity/Assets/WSNet2/Scripts/Core/WSNet2Serializer.cs
+++ b/wsnet2-unity/Assets/WSNet2/Scripts/Core/WSNet2Serializer.cs
@@ -165,10 +165,6 @@ namespace WSNet2
         public WSNet2SerializerException(string message, Exception innerException) : base(message, innerException)
         {
         }
-
-        protected WSNet2SerializerException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
     }
 
 }


### PR DESCRIPTION
- .NET 8 (LTS)
- ライブラリ更新
- テスト修正
  - msgpackのバイナリ比較だと差がでるケースがあったのでjsonで比較
- Exceptionの旧形式の不要メソッド削除