### PR TITLE
入室しようとした部屋がちょうど終了したときに待ち続けてしまうのを修正

### DIFF
--- a/server/game/repository.go
+++ b/server/game/repository.go
@@ -252,6 +252,10 @@ func (repo *Repository) joinRoom(ctx context.Context, id string, client *pb.Clie
 		return nil, WithCode(
 			xerrors.Errorf("context done: room=%v", room.Id),
 			codes.DeadlineExceeded)
+	case <-room.Done():
+		return nil, NormalWithCode(
+			xerrors.Errorf("room done: room=%v", room.Id),
+			codes.NotFound)
 	case room.msgCh <- msg:
 	}
 
@@ -261,6 +265,10 @@ func (repo *Repository) joinRoom(ctx context.Context, id string, client *pb.Clie
 		return nil, WithCode(
 			xerrors.Errorf("context done: room=%v", room.Id),
 			codes.DeadlineExceeded)
+	case <-room.Done():
+		return nil, NormalWithCode(
+			xerrors.Errorf("room done: room=%v", room.Id),
+			codes.NotFound)
 	case ewc := <-errch:
 		return nil, ewc
 	case joined = <-jch:


### PR DESCRIPTION
MsgJoinを送るタイミングでちょうどRoomが終了してメッセージループが止まってしまうと、
タイムアウトまで待ち続けることになってしまっていました。

room.Done()をチェックして正常系エラーのNotFoundを返すようにしました。
（入室しようとした部屋が見つからなかったときと同等のレスポンス）