### PR TITLE
gameでClient.hmacのraceを回避するためpeerそれぞれがhash.Hashを持つように

### DIFF
--- a/server/game/client.go
+++ b/server/game/client.go
@@ -1,9 +1,6 @@
 package game
 
 import (
-	"crypto/hmac"
-	"crypto/sha1"
-	"hash"
 	"sync"
 	"time"
 
@@ -44,7 +41,7 @@ type Client struct {
 	received     bool
 
 	authKey string
-	hmac    hash.Hash
+	macKey  string
 
 	logger log.Logger
 
@@ -85,7 +82,7 @@ func newClient(info *pb.ClientInfo, macKey string, room IRoom, isPlayer bool) (*
 		renewPeer: make(chan struct{}, 1),
 
 		authKey: RandomHex(room.ClientConf().AuthKeyLen),
-		hmac:    hmac.New(sha1.New, []byte(macKey)),
+		macKey:  macKey,
 
 		logger: room.Logger().With(log.KeyClient, info.Id),
 

--- a/server/game/peer.go
+++ b/server/game/peer.go
@@ -2,7 +2,10 @@ package game
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha1"
 	"errors"
+	"hash"
 	"net"
 	"sync"
 	"time"
@@ -30,6 +33,7 @@ type Peer struct {
 	client *Client
 	conn   *websocket.Conn
 	msgCh  chan binary.Msg
+	hmac   hash.Hash
 
 	done     chan struct{}
 	detached chan struct{}
@@ -45,6 +49,7 @@ func NewPeer(ctx context.Context, cli *Client, conn *websocket.Conn, lastEvSeq i
 		client: cli,
 		conn:   conn,
 		msgCh:  make(chan binary.Msg),
+		hmac:   hmac.New(sha1.New, []byte(cli.macKey)),
 
 		done:     make(chan struct{}),
 		detached: make(chan struct{}),
@@ -223,7 +228,7 @@ loop:
 		}
 		metrics.MessageRecv.Add(1)
 
-		msg, err := binary.UnmarshalMsg(p.client.hmac, data)
+		msg, err := binary.UnmarshalMsg(p.hmac, data)
 		if err != nil {
 			p.client.logger.Errorf("peer UnmarshalMsg (%v, %p): %+v", p.client.Id, p, err)
 			p.closeWithMessage(websocket.CloseInvalidFramePayloadData, err.Error())


### PR DESCRIPTION
peer毎にMsgLoopが回っているので、再接続時に古いPeerのMsgLoopがまだ生きている場合にhmacの計算が衝突することがありました。
peerごとにhmacオブジェクトを持つように修正しました。