### PR TITLE
C# Client: 送信時のレースコンディションを解消

### DIFF
--- a/wsnet2-unity/Assets/WSNet2/Scripts/Core/Connection.cs
+++ b/wsnet2-unity/Assets/WSNet2/Scripts/Core/Connection.cs
@@ -428,37 +428,46 @@ namespace WSNet2
         /// <param name="ct">ループ停止するトークン</param>
         private async Task Sender(WebSockConn ws, int seqNum, CancellationToken ct)
         {
-            while (true)
+            try
             {
-                if (!msgPool.Wait(ct))
-                {
-                    // ctがキャンセルされているとき falseが返るので終了
-                    return;
-                }
-
                 while (true)
                 {
-                    ArraySegment<byte>? msg;
-                    lock (senderLock)
+                    if (!msgPool.Wait(ct))
                     {
-                        // ctのキャンセルで終了, キャンセル後にmsgPool.Takeしない
-                        if (ct.IsCancellationRequested)
+                        // ctがキャンセルされているとき falseが返るので終了
+                        return;
+                    }
+
+                    while (true)
+                    {
+                        ArraySegment<byte>? msg;
+                        lock (senderLock)
                         {
-                            return;
+                            // ctのキャンセルで終了, キャンセル後にmsgPool.Takeしない
+                            if (ct.IsCancellationRequested)
+                            {
+                                return;
+                            }
+
+                            msg = msgPool.Take(seqNum);
                         }
 
-                        msg = msgPool.Take(seqNum);
-                    }
+                        if (!msg.HasValue)
+                        {
+                            break;
+                        }
 
-                    if (!msg.HasValue)
-                    {
-                        break;
+                        NetworkInformer.OnRoomSend(room, msg.Value);
+                        await ws.Send(msg.Value, ct);
+                        seqNum++;
                     }
-
-                    NetworkInformer.OnRoomSend(room, msg.Value);
-                    await ws.Send(msg.Value, ct);
-                    seqNum++;
                 }
+            }
+            finally
+            {
+                // 未送信Msgが残っていても新しいSenderが処理できるように通知する
+                // 空振りだったとしてもTakeがnullを返すだけなので無害
+                msgPool.Notify();
             }
         }
 

--- a/wsnet2-unity/Assets/WSNet2/Scripts/Core/Connection.cs
+++ b/wsnet2-unity/Assets/WSNet2/Scripts/Core/Connection.cs
@@ -38,8 +38,6 @@ namespace WSNet2
         volatile int pingInterval;
         volatile uint lastPingTime;
         CancellationTokenSource pingerDelayCanceller;
-        SemaphoreSlim sendSemaphore;
-        bool closed;
 
         TaskCompletionSource<Task> senderTaskSource;
         TaskCompletionSource<Task> pingerTaskSource;
@@ -48,6 +46,25 @@ namespace WSNet2
         uint evSeqNum;
 
         Logger logger;
+
+        class WebSockConn : IDisposable
+        {
+            public ClientWebSocket client;
+            public SemaphoreSlim sendSemaphore;
+            public bool closed;
+
+            public WebSockConn(ClientWebSocket client)
+            {
+                this.client = client;
+                this.sendSemaphore = new SemaphoreSlim(1, 1);
+                this.closed = false;
+            }
+
+            public void Dispose()
+            {
+                client.Dispose();
+            }
+        }
 
         /// <summary>
         ///   コンストラクタ
@@ -66,8 +83,6 @@ namespace WSNet2
             this.hmac = hmac;
             this.pingInterval = calcPingInterval(room.ClientDeadline);
             this.pingerDelayCanceller = new CancellationTokenSource();
-            this.sendSemaphore = new SemaphoreSlim(1, 1);
-            this.closed = false;
 
             this.evSeqNum = 0;
             this.evBufPool = new BlockingCollection<byte[]>(
@@ -214,7 +229,7 @@ namespace WSNet2
         /// <summary>
         ///   Websocketで接続する
         /// </summary>
-        private async Task<ClientWebSocket> Connect(CancellationToken ct)
+        private async Task<WebSockConn> Connect(CancellationToken ct)
         {
             var ws = new ClientWebSocket();
             var authdata = authgen.GenerateBearer(authKey, clientId);
@@ -232,13 +247,13 @@ namespace WSNet2
             SetTcpNoDelay(ws);
 
             logger?.Info("connected");
-            return ws;
+            return new WebSockConn(ws);
         }
 
         /// <summary>
         ///   Event受信ループ
         /// </summary>
-        private async Task Receiver(ClientWebSocket ws, CancellationToken ct)
+        private async Task Receiver(WebSockConn ws, CancellationToken ct)
         {
             try
             {
@@ -295,7 +310,7 @@ namespace WSNet2
         /// <summary>
         ///   Eventの受信
         /// </summary>
-        private async Task<Event> ReceiveEvent(ClientWebSocket ws, CancellationToken ct)
+        private async Task<Event> ReceiveEvent(WebSockConn ws, CancellationToken ct)
         {
             var buf = evBufPool.Take(ct);
             try
@@ -304,7 +319,7 @@ namespace WSNet2
                 while (true)
                 {
                     var seg = new ArraySegment<byte>(buf, pos, buf.Length - pos);
-                    var ret = await ws.ReceiveAsync(seg, ct);
+                    var ret = await ws.client.ReceiveAsync(seg, ct);
 
                     if (ret.MessageType == WebSocketMessageType.Close)
                     {
@@ -354,7 +369,7 @@ namespace WSNet2
         /// </summary>
         /// <param name="seqNum">開始Msg通し番号</param>
         /// <param name="ct">ループ停止するトークン</param>
-        private async Task Sender(ClientWebSocket ws, int seqNum, CancellationToken ct)
+        private async Task Sender(WebSockConn ws, int seqNum, CancellationToken ct)
         {
             while (true)
             {
@@ -381,7 +396,7 @@ namespace WSNet2
         /// <summary>
         ///   Ping送信ループ
         /// </summary>
-        private async Task Pinger(ClientWebSocket ws, CancellationToken ct)
+        private async Task Pinger(WebSockConn ws, CancellationToken ct)
         {
             var msg = new MsgPing(hmac);
 
@@ -415,51 +430,51 @@ namespace WSNet2
         /// <summary>
         ///   websocketメッセージを送信
         /// </summary>
-        private async Task Send(ClientWebSocket ws, ArraySegment<byte> msg, CancellationToken ct)
+        private async Task Send(WebSockConn ws, ArraySegment<byte> msg, CancellationToken ct)
         {
-            if (closed)
+            if (ws.closed)
             {
                 // SendCloseがsemaphore握りっぱなしになる対策で先にチェック
                 // ここすり抜けてsemaphore待ってしまったらご愁傷さま……
                 return;
             }
 
-            await sendSemaphore.WaitAsync(ct);
+            await ws.sendSemaphore.WaitAsync(ct);
             try
             {
-                if (closed)
+                if (ws.closed)
                 {
                     return;
                 }
 
                 NetworkInformer.OnRoomSend(room, msg);
-                await ws.SendAsync(msg, WebSocketMessageType.Binary, true, ct);
+                await ws.client.SendAsync(msg, WebSocketMessageType.Binary, true, ct);
             }
             finally
             {
-                sendSemaphore.Release();
+                ws.sendSemaphore.Release();
             }
         }
 
-        private async Task SendClose(ClientWebSocket ws, string msg, CancellationToken ct)
+        private async Task SendClose(WebSockConn ws, string msg, CancellationToken ct)
         {
-            await sendSemaphore.WaitAsync(ct);
+            await ws.sendSemaphore.WaitAsync(ct);
             try
             {
-                if (closed)
+                if (ws.closed)
                 {
                     return;
                 }
 
-                closed = true;
+                ws.closed = true;
 
                 var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
                 cts.CancelAfter(SendCloseTimeout);
-                await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, msg, cts.Token);
+                await ws.client.CloseAsync(WebSocketCloseStatus.NormalClosure, msg, cts.Token);
             }
             finally
             {
-                sendSemaphore.Release();
+                ws.sendSemaphore.Release();
             }
         }
 

--- a/wsnet2-unity/Assets/WSNet2/Scripts/Core/Connection.cs
+++ b/wsnet2-unity/Assets/WSNet2/Scripts/Core/Connection.cs
@@ -41,6 +41,7 @@ namespace WSNet2
 
         TaskCompletionSource<Task> senderTaskSource;
         TaskCompletionSource<Task> pingerTaskSource;
+        readonly object senderLock;
 
         BlockingCollection<byte[]> evBufPool;
         uint evSeqNum;
@@ -135,6 +136,7 @@ namespace WSNet2
             this.hmac = hmac;
             this.pingInterval = calcPingInterval(room.ClientDeadline);
             this.pingerDelayCanceller = new CancellationTokenSource();
+            this.senderLock = new object();
 
             this.evSeqNum = 0;
             this.evBufPool = new BlockingCollection<byte[]>(
@@ -214,7 +216,10 @@ namespace WSNet2
                 {
                     senderTaskSource.TrySetCanceled();
                     pingerTaskSource.TrySetCanceled();
-                    cts.Cancel();
+                    lock (senderLock)
+                    {
+                        cts.Cancel();
+                    }
                     if (connected)
                     {
                         connected = false;
@@ -431,12 +436,21 @@ namespace WSNet2
                     return;
                 }
 
-                ArraySegment<byte>? msg;
-                while ((msg = msgPool.Take(seqNum)).HasValue)
-                {
-                    if (ct.IsCancellationRequested)
+                while (true) {
+                    ArraySegment<byte>? msg;
+                    lock (senderLock)
                     {
-                        return; // ctのキャンセルで終了
+                        // ctのキャンセルで終了, キャンセル後にmsgPool.Takeしない
+                        if (ct.IsCancellationRequested)
+                        {
+                            return;
+                        }
+
+                        msg = msgPool.Take(seqNum);
+                    }
+
+                    if (!msg.HasValue) {
+                        break;
                     }
 
                     NetworkInformer.OnRoomSend(room, msg.Value);

--- a/wsnet2-unity/Assets/WSNet2/Scripts/Core/Connection.cs
+++ b/wsnet2-unity/Assets/WSNet2/Scripts/Core/Connection.cs
@@ -436,7 +436,8 @@ namespace WSNet2
                     return;
                 }
 
-                while (true) {
+                while (true)
+                {
                     ArraySegment<byte>? msg;
                     lock (senderLock)
                     {
@@ -449,7 +450,8 @@ namespace WSNet2
                         msg = msgPool.Take(seqNum);
                     }
 
-                    if (!msg.HasValue) {
+                    if (!msg.HasValue)
+                    {
                         break;
                     }
 

--- a/wsnet2-unity/Assets/WSNet2/Scripts/Core/Connection.cs
+++ b/wsnet2-unity/Assets/WSNet2/Scripts/Core/Connection.cs
@@ -358,7 +358,11 @@ namespace WSNet2
         {
             while (true)
             {
-                msgPool.Wait(ct);
+                if (!msgPool.Wait(ct))
+                {
+                    // ctがキャンセルされているとき falseが返るので終了
+                    return;
+                }
 
                 ArraySegment<byte>? msg;
                 while ((msg = msgPool.Take(seqNum)).HasValue)

--- a/wsnet2-unity/Assets/WSNet2/Scripts/Core/Connection.cs
+++ b/wsnet2-unity/Assets/WSNet2/Scripts/Core/Connection.cs
@@ -49,9 +49,9 @@ namespace WSNet2
 
         class WebSockConn : IDisposable
         {
-            public ClientWebSocket client;
-            public SemaphoreSlim sendSemaphore;
-            public bool closed;
+            ClientWebSocket client;
+            SemaphoreSlim sendSemaphore;
+            bool closed;
 
             public WebSockConn(ClientWebSocket client)
             {
@@ -63,6 +63,58 @@ namespace WSNet2
             public void Dispose()
             {
                 client.Dispose();
+            }
+
+            public Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> seg, CancellationToken ct)
+            {
+                return client.ReceiveAsync(seg, ct);
+            }
+
+            public async Task Send(ArraySegment<byte> msg, CancellationToken ct)
+            {
+                if (closed)
+                {
+                    // SendCloseがsemaphore握りっぱなしになる対策で先にチェック
+                    // ここすり抜けてsemaphore待ってしまったらご愁傷さま……
+                    return;
+                }
+
+                await sendSemaphore.WaitAsync(ct);
+                try
+                {
+                    if (closed)
+                    {
+                        return;
+                    }
+
+                    await client.SendAsync(msg, WebSocketMessageType.Binary, true, ct);
+                }
+                finally
+                {
+                    sendSemaphore.Release();
+                }
+            }
+
+            public async Task SendClose(string msg, CancellationToken ct)
+            {
+                await sendSemaphore.WaitAsync(ct);
+                try
+                {
+                    if (closed)
+                    {
+                        return;
+                    }
+
+                    closed = true;
+
+                    var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                    cts.CancelAfter(SendCloseTimeout);
+                    await client.CloseAsync(WebSocketCloseStatus.NormalClosure, msg, cts.Token);
+                }
+                finally
+                {
+                    sendSemaphore.Release();
+                }
             }
         }
 
@@ -319,13 +371,13 @@ namespace WSNet2
                 while (true)
                 {
                     var seg = new ArraySegment<byte>(buf, pos, buf.Length - pos);
-                    var ret = await ws.client.ReceiveAsync(seg, ct);
+                    var ret = await ws.ReceiveAsync(seg, ct);
 
                     if (ret.MessageType == WebSocketMessageType.Close)
                     {
                         // iOSでごく稀にws.CloseAsync()が返ってこないことがあるので別Taskで実行
                         // Semaphoreを握りっぱなしになるけどこの接続は終了するので基本的には問題ない
-                        Task.Run(async () => await SendClose(ws, ret.CloseStatusDescription, ct));
+                        Task.Run(async () => await ws.SendClose(ret.CloseStatusDescription, ct));
 
                         switch (ret.CloseStatus)
                         {
@@ -387,7 +439,8 @@ namespace WSNet2
                         return; // ctのキャンセルで終了
                     }
 
-                    await Send(ws, msg.Value, ct);
+                    NetworkInformer.OnRoomSend(room, msg.Value);
+                    await ws.Send(msg.Value, ct);
                     seqNum++;
                 }
             }
@@ -410,7 +463,8 @@ namespace WSNet2
                 var interval = Task.Delay(pingInterval, pingerDelayCanceller.Token);
                 var time = (uint)msg.SetTimestamp();
                 lastPingTime = time;
-                await Send(ws, msg.Value, ct);
+                NetworkInformer.OnRoomSend(room, msg.Value);
+                await ws.Send(msg.Value, ct);
                 try
                 {
                     await interval;
@@ -424,57 +478,6 @@ namespace WSNet2
                 {
                     // pingerDelayCancellerによるcancelは無視
                 }
-            }
-        }
-
-        /// <summary>
-        ///   websocketメッセージを送信
-        /// </summary>
-        private async Task Send(WebSockConn ws, ArraySegment<byte> msg, CancellationToken ct)
-        {
-            if (ws.closed)
-            {
-                // SendCloseがsemaphore握りっぱなしになる対策で先にチェック
-                // ここすり抜けてsemaphore待ってしまったらご愁傷さま……
-                return;
-            }
-
-            await ws.sendSemaphore.WaitAsync(ct);
-            try
-            {
-                if (ws.closed)
-                {
-                    return;
-                }
-
-                NetworkInformer.OnRoomSend(room, msg);
-                await ws.client.SendAsync(msg, WebSocketMessageType.Binary, true, ct);
-            }
-            finally
-            {
-                ws.sendSemaphore.Release();
-            }
-        }
-
-        private async Task SendClose(WebSockConn ws, string msg, CancellationToken ct)
-        {
-            await ws.sendSemaphore.WaitAsync(ct);
-            try
-            {
-                if (ws.closed)
-                {
-                    return;
-                }
-
-                ws.closed = true;
-
-                var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-                cts.CancelAfter(SendCloseTimeout);
-                await ws.client.CloseAsync(WebSocketCloseStatus.NormalClosure, msg, cts.Token);
-            }
-            finally
-            {
-                ws.sendSemaphore.Release();
             }
         }
 

--- a/wsnet2-unity/Assets/WSNet2/Scripts/Core/Connection.cs
+++ b/wsnet2-unity/Assets/WSNet2/Scripts/Core/Connection.cs
@@ -52,7 +52,7 @@ namespace WSNet2
         {
             ClientWebSocket client;
             SemaphoreSlim sendSemaphore;
-            bool closed;
+            volatile bool closed;
 
             public WebSockConn(ClientWebSocket client)
             {

--- a/wsnet2-unity/Assets/WSNet2/Scripts/Core/Msg/MsgPool.cs
+++ b/wsnet2-unity/Assets/WSNet2/Scripts/Core/Msg/MsgPool.cs
@@ -77,6 +77,12 @@ namespace WSNet2
             return true;
         }
 
+        /// <summary>Msgが存在することを通知</summary>
+        public void Notify()
+        {
+            hasMsg.TryAdd(true);
+        }
+
         /// <summary>
         ///   送信するバイト列を取得
         /// </summary>

--- a/wsnet2-unity/Assets/WSNet2/Scripts/Core/Msg/MsgPool.cs
+++ b/wsnet2-unity/Assets/WSNet2/Scripts/Core/Msg/MsgPool.cs
@@ -56,14 +56,25 @@ namespace WSNet2
         /// <summary>
         ///   Msgが来るまで待つ
         /// </summary>
+        /// <return>
+        ///   ctがキャンセルされている古いSenderから呼ばれていたときはfalse
+        /// </return>
         /// <remarks>
         ///   <para>
         ///     スレッドをブロックする
         ///   </para>
         /// </remarks>
-        public void Wait(CancellationToken ct)
+        public bool Wait(CancellationToken ct)
         {
             _ = hasMsg.Take(ct);
+
+            if (ct.IsCancellationRequested) {
+                // 古いConnectionから呼ばれていたとき、hasMsgを戻してfalseを返す
+                hasMsg.TryAdd(true);
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
クライアントメッセージのHMACが一致しないことがあるのを発見
websocket再接続の前後でのレースコンディションにより、送信バッファが別タスクから書き換えられる可能性があった

修正内容：
- キャンセル済み接続からのmsgPool読み出しを抑制
- websocket接続ごとに送信semaphoreと切断フラグを持つように整理

挙動の変更：
NetworkInformer.OnRoomSend()呼び出しタイミングが変更になり、切断後の送信も呼び出されるようになった
もともとこの機能はデバッグ時の計測用途のため影響は軽微（Conditional("DEBUG")が指定されている）